### PR TITLE
Don't densify sparse vectors when subsetting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,5 +56,5 @@ Suggests:
 StagedInstall: TRUE
 URL: https://github.com/rexyai/rsparse
 BugReports: https://github.com/rexyai/rsparse/issues
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 NeedsCompilation: yes

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -93,3 +93,7 @@ cpp_make_sparse_approximation <- function(mat_template, X, Y, sparse_matrix_type
     .Call(`_rsparse_cpp_make_sparse_approximation`, mat_template, X, Y, sparse_matrix_type, n_threads)
 }
 
+convert_indptr_to_rows <- function(indptr) {
+    .Call(`_rsparse_convert_indptr_to_rows`, indptr)
+}
+

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -93,7 +93,7 @@ cpp_make_sparse_approximation <- function(mat_template, X, Y, sparse_matrix_type
     .Call(`_rsparse_cpp_make_sparse_approximation`, mat_template, X, Y, sparse_matrix_type, n_threads)
 }
 
-convert_indptr_to_rows <- function(indptr) {
-    .Call(`_rsparse_convert_indptr_to_rows`, indptr)
+convert_indptr_to_rows <- function(indptr, n) {
+    .Call(`_rsparse_convert_indptr_to_rows`, indptr, n)
 }
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -165,6 +165,8 @@ get_indices_integer = function(i, max_i, index_names) {
 #' m = as(m, "RsparseMatrix")
 #' inherits(m[1:2, ], "RsparseMatrix")
 #' inherits(m[1:2, 3:4], "RsparseMatrix")
+#' inherits(m[1, , drop=TRUE], "sparseVector")
+#' inherits(m[1, 1, drop=TRUE], "numeric")
 NULL
 
 subset_csr = function(x, i, j, drop = TRUE) {
@@ -216,8 +218,16 @@ subset_csr = function(x, i, j, drop = TRUE) {
   col_names = if(is.null(col_names)) NULL else col_names[j]
   res@Dimnames = list(row_names, col_names)
 
-  if(isTRUE(drop) && (n_row == 1L || n_col == 1L))
-    res = as.vector(res)
+
+  if(isTRUE(drop) && (n_row == 1L || n_col == 1L)) {
+    if (n_row == 1L && n_col == 1L) {
+      res = ifelse(NROW(res@x), res@x, 0)
+    } else if (n_row == 1L) {
+      res = Matrix::sparseVector(res@x, res@j+1L, length=n_col)
+    } else {
+      res = Matrix::sparseVector(res@x, convert_indptr_to_rows(res@p), length=n_row)
+    }
+  }
   res
 }
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -225,7 +225,7 @@ subset_csr = function(x, i, j, drop = TRUE) {
     } else if (n_row == 1L) {
       res = Matrix::sparseVector(res@x, res@j+1L, length=n_col)
     } else {
-      res = Matrix::sparseVector(res@x, convert_indptr_to_rows(res@p), length=n_row)
+      res = Matrix::sparseVector(res@x, convert_indptr_to_rows(res@p, NROW(res@x)), length=n_row)
     }
   }
   res

--- a/man/slice.Rd
+++ b/man/slice.Rd
@@ -40,4 +40,6 @@ m = rsparsematrix(20, 20, 0.1)
 m = as(m, "RsparseMatrix")
 inherits(m[1:2, ], "RsparseMatrix")
 inherits(m[1:2, 3:4], "RsparseMatrix")
+inherits(m[1, , drop=TRUE], "sparseVector")
+inherits(m[1, 1, drop=TRUE], "numeric")
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -360,6 +360,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// convert_indptr_to_rows
+Rcpp::IntegerVector convert_indptr_to_rows(Rcpp::IntegerVector indptr);
+RcppExport SEXP _rsparse_convert_indptr_to_rows(SEXP indptrSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type indptr(indptrSEXP);
+    rcpp_result_gen = Rcpp::wrap(convert_indptr_to_rows(indptr));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_get_ftrl_weights", (DL_FUNC) &_rsparse_get_ftrl_weights, 1},
@@ -385,6 +396,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_arma_kmeans", (DL_FUNC) &_rsparse_arma_kmeans, 6},
     {"_rsparse_omp_thread_count", (DL_FUNC) &_rsparse_omp_thread_count, 0},
     {"_rsparse_cpp_make_sparse_approximation", (DL_FUNC) &_rsparse_cpp_make_sparse_approximation, 5},
+    {"_rsparse_convert_indptr_to_rows", (DL_FUNC) &_rsparse_convert_indptr_to_rows, 1},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -361,13 +361,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // convert_indptr_to_rows
-Rcpp::IntegerVector convert_indptr_to_rows(Rcpp::IntegerVector indptr);
-RcppExport SEXP _rsparse_convert_indptr_to_rows(SEXP indptrSEXP) {
+Rcpp::IntegerVector convert_indptr_to_rows(Rcpp::IntegerVector indptr, int n);
+RcppExport SEXP _rsparse_convert_indptr_to_rows(SEXP indptrSEXP, SEXP nSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type indptr(indptrSEXP);
-    rcpp_result_gen = Rcpp::wrap(convert_indptr_to_rows(indptr));
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    rcpp_result_gen = Rcpp::wrap(convert_indptr_to_rows(indptr, n));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -396,7 +397,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_arma_kmeans", (DL_FUNC) &_rsparse_arma_kmeans, 6},
     {"_rsparse_omp_thread_count", (DL_FUNC) &_rsparse_omp_thread_count, 0},
     {"_rsparse_cpp_make_sparse_approximation", (DL_FUNC) &_rsparse_cpp_make_sparse_approximation, 5},
-    {"_rsparse_convert_indptr_to_rows", (DL_FUNC) &_rsparse_convert_indptr_to_rows, 1},
+    {"_rsparse_convert_indptr_to_rows", (DL_FUNC) &_rsparse_convert_indptr_to_rows, 2},
     {NULL, NULL, 0}
 };
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -75,6 +75,19 @@ dMappedCSC extract_mapped_csc(Rcpp::S4 input) {
   return dMappedCSC(nrows, ncols, values.length(), (arma::uword *)row_indices.begin(), (arma::uword *)col_ptrs.begin(), (double *)values.begin());
 }
 
+// [[Rcpp::export]]
+Rcpp::IntegerVector convert_indptr_to_rows(Rcpp::IntegerVector indptr)
+{
+  /* Note: the output will have numeration starting at 1  */
+  if (indptr.size() <= 1) return Rcpp::IntegerVector();
+  std::vector<int> res;
+  for (size_t ix = 1; ix < indptr.size(); ix++) {
+    if (indptr[ix] > indptr[ix-1])
+      res.push_back(ix);
+  }
+  return Rcpp::wrap(res);
+}
+
 // returns number of available threads
 // omp_get_num_threads() for some reason doesn't work on all systems
 // check following link

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -76,16 +76,17 @@ dMappedCSC extract_mapped_csc(Rcpp::S4 input) {
 }
 
 // [[Rcpp::export]]
-Rcpp::IntegerVector convert_indptr_to_rows(Rcpp::IntegerVector indptr)
+Rcpp::IntegerVector convert_indptr_to_rows(Rcpp::IntegerVector indptr, int n)
 {
   /* Note: the output will have numeration starting at 1  */
-  if (indptr.size() <= 1) return Rcpp::IntegerVector();
-  std::vector<int> res;
+  Rcpp::IntegerVector res(n, 0);
+  if (n == 0) return res;
+  int curr = 0;
   for (size_t ix = 1; ix < indptr.size(); ix++) {
     if (indptr[ix] > indptr[ix-1])
-      res.push_back(ix);
+      res[curr++] = ix;
   }
-  return Rcpp::wrap(res);
+  return res;
 }
 
 // returns number of available threads


### PR DESCRIPTION
When slicing a CSR matrix for 1 row with `drop=TRUE`, it will convert the data into a dense vector, which is something one usually wants to avoid. This PR keeps it sparse, returning instead a `sparseVector` from the `Matrix` package.