### PR TITLE
Allow negative values in explicit MF

### DIFF
--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -112,8 +112,10 @@ WRMF = R6::R6Class(
       # strore item_ids in order to use them in predict method
       private$item_ids = colnames(c_ui)
 
-      logger$trace("check items in input are not negative")
-      stopifnot(all(c_ui@x >= 0))
+      if ((private$feedback != "explicit") || private$non_negative) {
+        logger$trace("check items in input are not negative")
+        stopifnot(all(c_ui@x >= 0))
+      }
 
       logger$trace("making another matrix for convenient traverse by users - transposing input matrix")
       c_iu = t(c_ui)


### PR DESCRIPTION
The matrix factorization `WRMF` class allows an explicit-feedback version, in which the model takes the values as they are instead of as binary. The code makes a check that the values are non-negative, but for the explicit-feedback version, there is no reason why the input values would have to be non-negative - for example, one might want to center them beforehand by subtracting some user/item bias, which results in a large fraction of negative values, but the model works just fine with that.

This PR skips the non-negative check for the explicit-feedback model.