### PR TITLE
Avoid negative initialization when using non_negative

### DIFF
--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -15,6 +15,11 @@
 #'   \item{\url{http://danielnee.com/2016/09/collaborative-filtering-using-alternating-least-squares/}}
 #'   \item{\url{http://www.benfrederickson.com/matrix-factorization/}}
 #'   \item{\url{http://www.benfrederickson.com/fast-implicit-matrix-factorization/}}
+#'   \item{Franc, Vojtech, Vaclav Hlavac, and Mirko Navara.
+#'         "Sequential coordinate-wise algorithm for the
+#'         non-negative least squares problem."
+#'         International Conference on Computer Analysis of Images
+#'         and Patterns. Springer, Berlin, Heidelberg, 2005.}
 #' }
 #' @export
 #' @examples
@@ -143,6 +148,8 @@ WRMF = R6::R6Class(
           )
         else
           self$components = flrnorm(private$rank, n_item)
+        if (private$non_negative)
+          self$components = abs(self$components)
       } else {
         stopifnot(is.matrix(self$components) || is.float(self$components))
         stopifnot(ncol(self$components) == n_item)

--- a/man/WRMF.Rd
+++ b/man/WRMF.Rd
@@ -30,6 +30,11 @@ preds = model$predict(cv, k = 10, not_recommend = cv)
   \item{\url{http://danielnee.com/2016/09/collaborative-filtering-using-alternating-least-squares/}}
   \item{\url{http://www.benfrederickson.com/matrix-factorization/}}
   \item{\url{http://www.benfrederickson.com/fast-implicit-matrix-factorization/}}
+  \item{Franc, Vojtech, Vaclav Hlavac, and Mirko Navara.
+        "Sequential coordinate-wise algorithm for the
+        non-negative least squares problem."
+        International Conference on Computer Analysis of Images
+        and Patterns. Springer, Berlin, Heidelberg, 2005.}
 }
 }
 \section{Super class}{


### PR DESCRIPTION
When using the `non_negative` option in `WRMF`, it tends to reach better end results when the initialization of the factors is also non-negative. This PR fixes it and also adds the reference method to the docs (taken from https://github.com/linxihui/NNLM).