### PR TITLE
Explicit solver in C++

### DIFF
--- a/R/MatrixFactorizationRecommender.R
+++ b/R/MatrixFactorizationRecommender.R
@@ -71,6 +71,8 @@ MatrixFactorizationRecommender = R6::R6Class(
         data.table::setattr(predicted_item_ids, "dimnames", list(uids, NULL))
         data.table::setattr(indices, "ids", predicted_item_ids)
       }
+      if (self$glob_mean != 0.)
+        attr(indices, "scores") = attr(indices, "scores") + self$glob_mean
       indices
     },
     get_similar_items = function(item_id, k = ncol(self$components), ... ) {

--- a/R/MatrixFactorizationRecommender.R
+++ b/R/MatrixFactorizationRecommender.R
@@ -115,6 +115,8 @@ MatrixFactorizationRecommender = R6::R6Class(
     },
     # L2 normalized components
     components_ = NULL,
-    components_l2 = NULL
+    components_l2 = NULL,
+    # biases
+    add_biases = FALSE
   )
 )

--- a/R/MatrixFactorizationRecommender.R
+++ b/R/MatrixFactorizationRecommender.R
@@ -6,6 +6,8 @@ MatrixFactorizationRecommender = R6::R6Class(
   public = list(
     #' @field components item embeddings
     components = NULL,
+    #' @field glob_mean global mean (for centering values in explicit feedback)
+    glob_mean = 0.,
     #' @description recommends items for users
     #' @param x user-item interactions matrix (usually sparse - `Matrix::sparseMatrix`).Users are
     #' rows and items are columns

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -89,12 +89,12 @@ als_explicit_float <- function(m_csc_r, m_values_orig, XR, YR, lambda, n_threads
     .Call(`_rsparse_als_explicit_float`, m_csc_r, m_values_orig, XR, YR, lambda, n_threads, solver, cg_steps, calc_user_bias, calc_item_bias, non_negative)
 }
 
-initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda) {
-    invisible(.Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda))
+initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative) {
+    invisible(.Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative))
 }
 
-initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda) {
-    invisible(.Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda))
+initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative) {
+    invisible(.Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative))
 }
 
 deep_copy <- function(x) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,16 +81,16 @@ als_implicit_float <- function(m_csc_r, XR, YR, XtXR, lambda, n_threads, solver,
     .Call(`_rsparse_als_implicit_float`, m_csc_r, XR, YR, XtXR, lambda, n_threads, solver, cg_steps, non_negative)
 }
 
-als_explicit_double <- function(m_csc_r, X, Y, lambda, n_threads, solver, cg_steps = 3L, non_negative = FALSE) {
-    .Call(`_rsparse_als_explicit_double`, m_csc_r, X, Y, lambda, n_threads, solver, cg_steps, non_negative)
+als_explicit_double <- function(m_csc_r, m_values_orig, X, Y, lambda, n_threads, solver, cg_steps = 3L, calc_user_bias = FALSE, calc_item_bias = FALSE, non_negative = FALSE) {
+    .Call(`_rsparse_als_explicit_double`, m_csc_r, m_values_orig, X, Y, lambda, n_threads, solver, cg_steps, calc_user_bias, calc_item_bias, non_negative)
 }
 
-als_explicit_float <- function(m_csc_r, XR, YR, lambda, n_threads, solver, cg_steps = 3L, non_negative = FALSE) {
-    .Call(`_rsparse_als_explicit_float`, m_csc_r, XR, YR, lambda, n_threads, solver, cg_steps, non_negative)
+als_explicit_float <- function(m_csc_r, m_values_orig, XR, YR, lambda, n_threads, solver, cg_steps = 3L, calc_user_bias = FALSE, calc_item_bias = FALSE, non_negative = FALSE) {
+    .Call(`_rsparse_als_explicit_float`, m_csc_r, m_values_orig, XR, YR, lambda, n_threads, solver, cg_steps, calc_user_bias, calc_item_bias, non_negative)
 }
 
-als_loss_explicit <- function(m_csc_r, X, Y, lambda, n_threads) {
-    .Call(`_rsparse_als_loss_explicit`, m_csc_r, X, Y, lambda, n_threads)
+deep_copy <- function(x) {
+    .Call(`_rsparse_deep_copy`, x)
 }
 
 rankmf_solver_double <- function(x_r, W, H, W2_grad, H2_grad, user_features_r, item_features_r, rank, n_updates, learning_rate = 0.01, gamma = 1, lambda_user = 0.0, lambda_item_positive = 0.0, lambda_item_negative = 0.0, n_threads = 1L, update_items = TRUE, loss = 0L, kernel = 0L, max_negative_samples = 50L, margin = 0.1, optimizer = 0L, report_progress = 10L) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,6 +81,14 @@ als_implicit_float <- function(m_csc_r, XR, YR, XtXR, lambda, n_threads, solver,
     .Call(`_rsparse_als_implicit_float`, m_csc_r, XR, YR, XtXR, lambda, n_threads, solver, cg_steps, non_negative)
 }
 
+als_explicit_double <- function(m_csc_r, X, Y, lambda, n_threads, solver, cg_steps = 3L, non_negative = FALSE) {
+    .Call(`_rsparse_als_explicit_double`, m_csc_r, X, Y, lambda, n_threads, solver, cg_steps, non_negative)
+}
+
+als_explicit_float <- function(m_csc_r, XR, YR, lambda, n_threads, solver, cg_steps = 3L, non_negative = FALSE) {
+    .Call(`_rsparse_als_explicit_float`, m_csc_r, XR, YR, lambda, n_threads, solver, cg_steps, non_negative)
+}
+
 als_loss_explicit <- function(m_csc_r, X, Y, lambda, n_threads) {
     .Call(`_rsparse_als_loss_explicit`, m_csc_r, X, Y, lambda, n_threads)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -89,6 +89,14 @@ als_explicit_float <- function(m_csc_r, m_values_orig, XR, YR, lambda, n_threads
     .Call(`_rsparse_als_explicit_float`, m_csc_r, m_values_orig, XR, YR, lambda, n_threads, solver, cg_steps, calc_user_bias, calc_item_bias, non_negative)
 }
 
+initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda) {
+    invisible(.Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda))
+}
+
+initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda) {
+    invisible(.Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda))
+}
+
 deep_copy <- function(x) {
     .Call(`_rsparse_deep_copy`, x)
 }

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -333,7 +333,7 @@ WRMF = R6::R6Class(
         x = t(x)
         if (private$add_biases) {
           x_orig = deep_copy(x@x)
-          x@x = x_orig
+          x@x = deep_copy(x@x)
         } else {
           x_orig = numeric(0L)
         }

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -192,7 +192,8 @@ WRMF = R6::R6Class(
           initialize_biases_double(c_ui, c_iu,
                                    user_bias,
                                    item_bias,
-                                   private$lambda)
+                                   private$lambda,
+                                   private$non_negative)
           self$components[private$rank, ] = item_bias
           private$U[1L, ] = user_bias
         } else {
@@ -201,7 +202,8 @@ WRMF = R6::R6Class(
           initialize_biases_float(c_ui, c_iu,
                                   user_bias,
                                   item_bias,
-                                  private$lambda)
+                                  private$lambda,
+                                  private$non_negative)
           self$components[private$rank, ] = item_bias
           private$U[1L, ] = user_bias
         }

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -59,7 +59,7 @@ WRMF = R6::R6Class(
     #' @param cg_steps \code{integer > 0} - max number of internal steps in conjugate gradient
     #' (if "conjugate_gradient" solver used). \code{cg_steps = 3} by default.
     #' Controls precision of linear equation solution at the each ALS step. Usually no need to tune this parameter
-    #' @param precision one of \code{c("double", "float")}. Should embeeding matrices be
+    #' @param precision one of \code{c("double", "float")}. Should embedding matrices be
     #' numeric or float (from \code{float} package). The latter is usually 2x faster and
     #' consumes less RAM. BUT \code{float} matrices are not "base" objects. Use carefully.
     #' @param ... not used at the moment
@@ -170,7 +170,7 @@ WRMF = R6::R6Class(
             nrow = private$rank
           )
         else
-          self$components = flrnorm(private$rank, n_item)
+          self$components = flrnorm(private$rank, n_item, 0, 0.01)
         if (private$non_negative)
           self$components = abs(self$components)
       } else {
@@ -194,8 +194,6 @@ WRMF = R6::R6Class(
                                    item_bias,
                                    private$lambda,
                                    private$non_negative)
-          self$components[private$rank, ] = item_bias
-          private$U[1L, ] = user_bias
         } else {
           user_bias = float(n_user)
           item_bias = float(n_item)
@@ -204,9 +202,9 @@ WRMF = R6::R6Class(
                                   item_bias,
                                   private$lambda,
                                   private$non_negative)
-          self$components[private$rank, ] = item_bias
-          private$U[1L, ] = user_bias
         }
+        self$components[private$rank, ] = item_bias
+        private$U[1L, ] = user_bias
       }
 
       logger$info("starting factorization with %d threads", getOption("rsparse_omp_threads", 1L))

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -184,6 +184,29 @@ WRMF = R6::R6Class(
         # make float diagonal matrix - if first component is double - result will be automatically casted to double
         fl(diag(x = private$lambda, nrow = private$rank, ncol = private$rank))
 
+      if (private$add_biases) {
+        logger$info("initializing biases")
+        if (private$precision == "double") {
+          user_bias = numeric(n_user)
+          item_bias = numeric(n_item)
+          initialize_biases_double(c_ui, c_iu,
+                                   user_bias,
+                                   item_bias,
+                                   private$lambda)
+          self$components[private$rank, ] = item_bias
+          private$U[1L, ] = user_bias
+        } else {
+          user_bias = float(n_user)
+          item_bias = float(n_item)
+          initialize_biases_float(c_ui, c_iu,
+                                  user_bias,
+                                  item_bias,
+                                  private$lambda)
+          self$components[private$rank, ] = item_bias
+          private$U[1L, ] = user_bias
+        }
+      }
+
       logger$info("starting factorization with %d threads", getOption("rsparse_omp_threads", 1L))
       trace_lst = vector("list", n_iter)
       loss_prev_iter = Inf

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -322,8 +322,7 @@ WRMF = R6::R6Class(
       else
         setattr(res@Data, "dimnames", list(rownames(x), NULL))
       res
-    },
-    glob_mean = 0.
+    }
   ),
   #### private -----
   private = list(

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -15,6 +15,11 @@
 #'   \item{\url{http://danielnee.com/2016/09/collaborative-filtering-using-alternating-least-squares/}}
 #'   \item{\url{http://www.benfrederickson.com/matrix-factorization/}}
 #'   \item{\url{http://www.benfrederickson.com/fast-implicit-matrix-factorization/}}
+#'   \item{Franc, Vojtech, Vaclav Hlavac, and Mirko Navara.
+#'         "Sequential coordinate-wise algorithm for the
+#'         non-negative least squares problem."
+#'         International Conference on Computer Analysis of Images
+#'         and Patterns. Springer, Berlin, Heidelberg, 2005.}
 #' }
 #' @export
 #' @examples
@@ -143,6 +148,8 @@ WRMF = R6::R6Class(
           )
         else
           self$components = flrnorm(private$rank, n_item)
+        if (private$non_negative)
+          self$components = abs(self$components)
       } else {
         stopifnot(is.matrix(self$components) || is.float(self$components))
         stopifnot(ncol(self$components) == n_item)

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -333,7 +333,6 @@ WRMF = R6::R6Class(
         x = t(x)
         if (private$add_biases) {
           x_orig = deep_copy(x@x)
-          x@x = deep_copy(x@x)
         } else {
           x_orig = numeric(0L)
         }

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -137,6 +137,7 @@ WRMF = R6::R6Class(
         c_ui@x = c_ui@x - self$glob_mean
       }
       if (private$add_biases) {
+        c_ui@x = deep_copy(c_ui@x)
         c_ui_orig = deep_copy(c_ui@x)
       }
       else {

--- a/inst/include/nnls.hpp
+++ b/inst/include/nnls.hpp
@@ -5,24 +5,25 @@
 #define MAX_ITER 500
 
 template <class T>
-void scd_ls_update(arma::subview_col<T> Hj,
-                   const arma::Mat<T> &WtW,
+arma::Col<T> scd_ls_update(const arma::Mat<T> &WtW,
                    arma::Col<T> &mu,
                    uint max_iter,
-                   double rel_tol) {
+                   double rel_tol,
+                   const arma::Col<T> &initial) {
   // Problem:  Aj = W * Hj
   // Method: sequential coordinate-wise descent when loss function = square error
   // WtW = W^T W
   // WtAj = W^T Aj
 
+  arma::Col<T> res = initial;
   auto WtW_diag = WtW.diag();
   for (auto t = 0; t < max_iter; t++) {
     T rel_err = 0;
     for (auto k = 0; k < WtW.n_cols; k++) {
-      T current = Hj(k);
+      T current = res(k);
       auto update = current - mu(k) / WtW_diag.at(k);
       if(update < 0) update = 0;
-      Hj(k) = update;
+      res(k) = update;
       if (update != current) {
         mu += (update - current) * WtW.col(k);
         auto current_err = std::abs(current - update) / (std::abs(current) + TINY_NUM);
@@ -31,6 +32,7 @@ void scd_ls_update(arma::subview_col<T> Hj,
     }
     if (rel_err <= rel_tol) break;
   }
+  return res;
 }
 
 template <class T>
@@ -41,15 +43,15 @@ arma::Mat<T> c_nnls(const arma::Mat<T> &x,
   arma::Mat<T> H(x.n_cols, y.n_cols, arma::fill::randu);
   arma::Mat<T> Wt = x.t();
 
-  arma::Mat<T> WtW = Wt * Wt.t();
+  arma::Mat<T> WtW = Wt * x;
   arma::Col<T> mu, sumW;
 
   // for stability: avoid divided by 0
   WtW.diag() += TINY_NUM;
 
-  for (unsigned int j = 0; j < y.n_cols; j++) {
+  for (auto j = 0; j < y.n_cols; j++) {
     mu = WtW * H.col(j) - Wt * y.col(j);
-    scd_ls_update<T>(H.col(j), WtW, mu, max_iter, rel_tol);
+    H.col(j) = scd_ls_update<T>(WtW, mu, max_iter, rel_tol, H.col(j));
   }
   return (H);
 }

--- a/man/MatrixFactorizationRecommender.Rd
+++ b/man/MatrixFactorizationRecommender.Rd
@@ -11,6 +11,8 @@ All matrix factorization recommenders inherit from this class
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
 \item{\code{components}}{item embeddings}
+
+\item{\code{glob_mean}}{global mean (for centering values in explicit feedback)}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/WRMF.Rd
+++ b/man/WRMF.Rd
@@ -6,7 +6,7 @@
 \description{
 Creates a matrix factorization model which is solved through Alternating Least Squares (Weighted ALS for implicit feedback).
 For implicit feedback see "Collaborative Filtering for Implicit Feedback Datasets" (Hu, Koren, Volinsky).
-For explicit feedback it corresponds to the classic model for rating matrix decomposition with MSE error (without biases at the moment).
+For explicit feedback it corresponds to the classic model for rating matrix decomposition with MSE error.
 These two algorithms are proven to work well in recommender systems.
 }
 \examples{
@@ -68,6 +68,7 @@ creates WRMF model
   init = NULL,
   preprocess = identity,
   feedback = c("implicit", "explicit"),
+  add_biases = ifelse(feedback[1] == "explicit", TRUE, FALSE),
   non_negative = FALSE,
   solver = c("conjugate_gradient", "cholesky"),
   cg_steps = 3L,
@@ -96,7 +97,11 @@ Note that it will not automatically add +1 to the weights of the positive entrie
 
 \item{\code{feedback}}{\code{character} - feedback type - one of \code{c("implicit", "explicit")}}
 
-\item{\code{non_negative}}{logical, whether to perform non-negative factorization}
+\item{\code{add_biases}}{\code{logical} - whether to add user and item biases in the explicit feedback
+models. These will be treated as additional components, so the actual rank will be reduced
+by 2. The biases will be taken as the first and last components.}
+
+\item{\code{non_negative}}{\code{logical}, whether to perform non-negative factorization}
 
 \item{\code{solver}}{\code{character} - solver for "implicit feedback" problem.
 One of \code{c("conjugate_gradient", "cholesky")}.

--- a/man/WRMF.Rd
+++ b/man/WRMF.Rd
@@ -112,7 +112,7 @@ on par with \code{"cholesky"}}
 (if "conjugate_gradient" solver used). \code{cg_steps = 3} by default.
 Controls precision of linear equation solution at the each ALS step. Usually no need to tune this parameter}
 
-\item{\code{precision}}{one of \code{c("double", "float")}. Should embeeding matrices be
+\item{\code{precision}}{one of \code{c("double", "float")}. Should embedding matrices be
 numeric or float (from \code{float} package). The latter is usually 2x faster and
 consumes less RAM. BUT \code{float} matrices are not "base" objects. Use carefully.}
 

--- a/man/WRMF.Rd
+++ b/man/WRMF.Rd
@@ -30,6 +30,11 @@ preds = model$predict(cv, k = 10, not_recommend = cv)
   \item{\url{http://danielnee.com/2016/09/collaborative-filtering-using-alternating-least-squares/}}
   \item{\url{http://www.benfrederickson.com/matrix-factorization/}}
   \item{\url{http://www.benfrederickson.com/fast-implicit-matrix-factorization/}}
+  \item{Franc, Vojtech, Vaclav Hlavac, and Mirko Navara.
+        "Sequential coordinate-wise algorithm for the
+        non-negative least squares problem."
+        International Conference on Computer Analysis of Images
+        and Patterns. Springer, Berlin, Heidelberg, 2005.}
 }
 }
 \section{Super class}{

--- a/man/WRMF.Rd
+++ b/man/WRMF.Rd
@@ -122,7 +122,12 @@ consumes less RAM. BUT \code{float} matrices are not "base" objects. Use careful
 \subsection{Method \code{fit_transform()}}{
 fits the model
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{WRMF$fit_transform(x, n_iter = 10L, convergence_tol = 0.005, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{WRMF$fit_transform(
+  x,
+  n_iter = 10L,
+  convergence_tol = ifelse(private$feedback == "implicit", 0.005, 0.001),
+  ...
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -326,8 +326,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // initialize_biases_double
-void initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda);
-RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP) {
+void initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool non_negative);
+RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP non_negativeSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
@@ -335,13 +335,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::Col<double>& >::type user_bias(user_biasSEXP);
     Rcpp::traits::input_parameter< arma::Col<double>& >::type item_bias(item_biasSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
-    initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda);
+    Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
+    initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative);
     return R_NilValue;
 END_RCPP
 }
 // initialize_biases_float
-void initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda);
-RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP) {
+void initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool non_negative);
+RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP non_negativeSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
@@ -349,7 +350,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::S4& >::type user_bias(user_biasSEXP);
     Rcpp::traits::input_parameter< Rcpp::S4& >::type item_bias(item_biasSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
-    initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda);
+    Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
+    initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative);
     return R_NilValue;
 END_RCPP
 }
@@ -521,8 +523,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 9},
     {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 11},
     {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 11},
-    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 5},
-    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 5},
+    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 6},
+    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 6},
     {"_rsparse_deep_copy", (DL_FUNC) &_rsparse_deep_copy, 1},
     {"_rsparse_rankmf_solver_double", (DL_FUNC) &_rsparse_rankmf_solver_double, 22},
     {"_rsparse_rankmf_solver_float", (DL_FUNC) &_rsparse_rankmf_solver_float, 22},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -284,53 +284,55 @@ BEGIN_RCPP
 END_RCPP
 }
 // als_explicit_double
-double als_explicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, bool non_negative);
-RcppExport SEXP _rsparse_als_explicit_double(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP non_negativeSEXP) {
+double als_explicit_double(const Rcpp::S4& m_csc_r, arma::Col<double>& m_values_orig, arma::mat& X, arma::mat& Y, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, bool calc_user_bias, bool calc_item_bias, bool non_negative);
+RcppExport SEXP _rsparse_als_explicit_double(SEXP m_csc_rSEXP, SEXP m_values_origSEXP, SEXP XSEXP, SEXP YSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP calc_user_biasSEXP, SEXP calc_item_biasSEXP, SEXP non_negativeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
+    Rcpp::traits::input_parameter< arma::Col<double>& >::type m_values_orig(m_values_origSEXP);
     Rcpp::traits::input_parameter< arma::mat& >::type X(XSEXP);
     Rcpp::traits::input_parameter< arma::mat& >::type Y(YSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
     Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< bool >::type calc_user_bias(calc_user_biasSEXP);
+    Rcpp::traits::input_parameter< bool >::type calc_item_bias(calc_item_biasSEXP);
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_explicit_double(m_csc_r, X, Y, lambda, n_threads, solver, cg_steps, non_negative));
+    rcpp_result_gen = Rcpp::wrap(als_explicit_double(m_csc_r, m_values_orig, X, Y, lambda, n_threads, solver, cg_steps, calc_user_bias, calc_item_bias, non_negative));
     return rcpp_result_gen;
 END_RCPP
 }
 // als_explicit_float
-double als_explicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& XR, Rcpp::S4& YR, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, bool non_negative);
-RcppExport SEXP _rsparse_als_explicit_float(SEXP m_csc_rSEXP, SEXP XRSEXP, SEXP YRSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP non_negativeSEXP) {
+double als_explicit_float(const Rcpp::S4& m_csc_r, arma::Col<double>& m_values_orig, Rcpp::S4& XR, Rcpp::S4& YR, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, bool calc_user_bias, bool calc_item_bias, bool non_negative);
+RcppExport SEXP _rsparse_als_explicit_float(SEXP m_csc_rSEXP, SEXP m_values_origSEXP, SEXP XRSEXP, SEXP YRSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP calc_user_biasSEXP, SEXP calc_item_biasSEXP, SEXP non_negativeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
+    Rcpp::traits::input_parameter< arma::Col<double>& >::type m_values_orig(m_values_origSEXP);
     Rcpp::traits::input_parameter< Rcpp::S4& >::type XR(XRSEXP);
     Rcpp::traits::input_parameter< Rcpp::S4& >::type YR(YRSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
     Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< bool >::type calc_user_bias(calc_user_biasSEXP);
+    Rcpp::traits::input_parameter< bool >::type calc_item_bias(calc_item_biasSEXP);
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_explicit_float(m_csc_r, XR, YR, lambda, n_threads, solver, cg_steps, non_negative));
+    rcpp_result_gen = Rcpp::wrap(als_explicit_float(m_csc_r, m_values_orig, XR, YR, lambda, n_threads, solver, cg_steps, calc_user_bias, calc_item_bias, non_negative));
     return rcpp_result_gen;
 END_RCPP
 }
-// als_loss_explicit
-double als_loss_explicit(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, double lambda, unsigned n_threads);
-RcppExport SEXP _rsparse_als_loss_explicit(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP) {
+// deep_copy
+SEXP deep_copy(SEXP x);
+RcppExport SEXP _rsparse_deep_copy(SEXP xSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
-    Rcpp::traits::input_parameter< arma::mat& >::type X(XSEXP);
-    Rcpp::traits::input_parameter< arma::mat& >::type Y(YSEXP);
-    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
-    Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_loss_explicit(m_csc_r, X, Y, lambda, n_threads));
+    Rcpp::traits::input_parameter< SEXP >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(deep_copy(x));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -488,9 +490,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_dense_csc_prod", (DL_FUNC) &_rsparse_dense_csc_prod, 3},
     {"_rsparse_als_implicit_double", (DL_FUNC) &_rsparse_als_implicit_double, 9},
     {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 9},
-    {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 8},
-    {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 8},
-    {"_rsparse_als_loss_explicit", (DL_FUNC) &_rsparse_als_loss_explicit, 5},
+    {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 11},
+    {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 11},
+    {"_rsparse_deep_copy", (DL_FUNC) &_rsparse_deep_copy, 1},
     {"_rsparse_rankmf_solver_double", (DL_FUNC) &_rsparse_rankmf_solver_double, 22},
     {"_rsparse_rankmf_solver_float", (DL_FUNC) &_rsparse_rankmf_solver_float, 22},
     {"_rsparse_top_product", (DL_FUNC) &_rsparse_top_product, 6},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -325,6 +325,34 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// initialize_biases_double
+void initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda);
+RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csr_r(m_csr_rSEXP);
+    Rcpp::traits::input_parameter< arma::Col<double>& >::type user_bias(user_biasSEXP);
+    Rcpp::traits::input_parameter< arma::Col<double>& >::type item_bias(item_biasSEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
+    initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda);
+    return R_NilValue;
+END_RCPP
+}
+// initialize_biases_float
+void initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda);
+RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csr_r(m_csr_rSEXP);
+    Rcpp::traits::input_parameter< Rcpp::S4& >::type user_bias(user_biasSEXP);
+    Rcpp::traits::input_parameter< Rcpp::S4& >::type item_bias(item_biasSEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
+    initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda);
+    return R_NilValue;
+END_RCPP
+}
 // deep_copy
 SEXP deep_copy(SEXP x);
 RcppExport SEXP _rsparse_deep_copy(SEXP xSEXP) {
@@ -493,6 +521,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 9},
     {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 11},
     {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 11},
+    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 5},
+    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 5},
     {"_rsparse_deep_copy", (DL_FUNC) &_rsparse_deep_copy, 1},
     {"_rsparse_rankmf_solver_double", (DL_FUNC) &_rsparse_rankmf_solver_double, 22},
     {"_rsparse_rankmf_solver_float", (DL_FUNC) &_rsparse_rankmf_solver_float, 22},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -283,6 +283,42 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// als_explicit_double
+double als_explicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, bool non_negative);
+RcppExport SEXP _rsparse_als_explicit_double(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP non_negativeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
+    Rcpp::traits::input_parameter< arma::mat& >::type X(XSEXP);
+    Rcpp::traits::input_parameter< arma::mat& >::type Y(YSEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
+    Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
+    Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
+    rcpp_result_gen = Rcpp::wrap(als_explicit_double(m_csc_r, X, Y, lambda, n_threads, solver, cg_steps, non_negative));
+    return rcpp_result_gen;
+END_RCPP
+}
+// als_explicit_float
+double als_explicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& XR, Rcpp::S4& YR, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, bool non_negative);
+RcppExport SEXP _rsparse_als_explicit_float(SEXP m_csc_rSEXP, SEXP XRSEXP, SEXP YRSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP non_negativeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
+    Rcpp::traits::input_parameter< Rcpp::S4& >::type XR(XRSEXP);
+    Rcpp::traits::input_parameter< Rcpp::S4& >::type YR(YRSEXP);
+    Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
+    Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
+    Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
+    rcpp_result_gen = Rcpp::wrap(als_explicit_float(m_csc_r, XR, YR, lambda, n_threads, solver, cg_steps, non_negative));
+    return rcpp_result_gen;
+END_RCPP
+}
 // als_loss_explicit
 double als_loss_explicit(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, double lambda, unsigned n_threads);
 RcppExport SEXP _rsparse_als_loss_explicit(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP) {
@@ -452,6 +488,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_dense_csc_prod", (DL_FUNC) &_rsparse_dense_csc_prod, 3},
     {"_rsparse_als_implicit_double", (DL_FUNC) &_rsparse_als_implicit_double, 9},
     {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 9},
+    {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 8},
+    {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 8},
     {"_rsparse_als_loss_explicit", (DL_FUNC) &_rsparse_als_loss_explicit, 5},
     {"_rsparse_rankmf_solver_double", (DL_FUNC) &_rsparse_rankmf_solver_double, 22},
     {"_rsparse_rankmf_solver_float", (DL_FUNC) &_rsparse_rankmf_solver_float, 22},


### PR DESCRIPTION
This PR adds a copycat version of the `als_implicit_fun` with minor changes for it work in the explicit feedback case. This is my first time using armadillo so I'm not sure I'm doing things the best way here. Particularly, I didn't get how to add values to the diagonal of a matrix (what's written in their docs doesn't compile), so this line can perhaps be done better:
```cpp
 const arma::Mat<T> inv = X_nnz * X_nnz.t()
                            + regularization * arma::Mat<T>(X_nnz.n_rows, X_nnz.n_rows, arma::fill::eye);
```

In addition, the PR also performs mean centering when the inputs are not constrained to be non-negative. However I wasn't sure how to add an extra public attribute to an R6 class, so I added `glob_mean` to the list of public attributes definitions, but R complains that it's not documented. If I remove the line that adds it, it will throw an error when trying to add it dynamically as an attribute:
```
Error in self$glob_mean = mean(c_ui@x) : 
  cannot add bindings to a locked environment
```
Even though it somehow doesn't throw such error when adding `self$components` which was not declared beforehand.


As a next step, I also wanted to add biases to the model, but I'm not sure about the best way of going around it from a usability point of view. I think the best way would be to create a matrix for components having dimension `rank+2` and also outputing a matrix of dimension `rank+2` when calling transform, with one row/column in each one set to ones to match the other. What do you think about it?


Also wanted to make other potential changes:
* When calling `transform`, I think it'd be a better idea to always use the Cholesky solver as the CG one usually doesn't reach the optimal solution, especially when starting from zero which is what happens in `transform`.
* The library has the non-negative solver in an installable header, but I don't think one would want that file to be installed. Better move the header to `/src` instead.
