### PR TITLE
Re-add mean centering and bias init

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -90,11 +90,11 @@ als_explicit_float <- function(m_csc_r, X_, Y_, lambda, n_threads, solver, cg_st
 }
 
 initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative) {
-    invisible(.Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative))
+    .Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative)
 }
 
 initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative) {
-    invisible(.Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative))
+    .Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative)
 }
 
 deep_copy <- function(x) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -322,9 +322,10 @@ BEGIN_RCPP
 END_RCPP
 }
 // initialize_biases_double
-void initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool non_negative);
+double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool non_negative);
 RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP non_negativeSEXP) {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csr_r(m_csr_rSEXP);
@@ -332,14 +333,15 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::Col<double>& >::type item_bias(item_biasSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
-    initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative);
-    return R_NilValue;
+    rcpp_result_gen = Rcpp::wrap(initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative));
+    return rcpp_result_gen;
 END_RCPP
 }
 // initialize_biases_float
-void initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool non_negative);
+double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool non_negative);
 RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP non_negativeSEXP) {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csr_r(m_csr_rSEXP);
@@ -347,8 +349,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::S4& >::type item_bias(item_biasSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
-    initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative);
-    return R_NilValue;
+    rcpp_result_gen = Rcpp::wrap(initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative));
+    return rcpp_result_gen;
 END_RCPP
 }
 // deep_copy

--- a/src/SolverAlsWrmf.cpp
+++ b/src/SolverAlsWrmf.cpp
@@ -313,6 +313,7 @@ double initialize_biases(const dMappedCSC& ConfCSC,
   double glob_mean = 0;
   for (size_t ix = 0; ix < ConfCSC.nnz; ix++)
     glob_mean += (ConfCSC.values[ix] - glob_mean) / (double)(ix+1);
+#pragma omp simd
   for (size_t ix = 0; ix < ConfCSC.nnz; ix++) {
     ConfCSC.values[ix] -= glob_mean;
     ConfCSR.values[ix] -= glob_mean;


### PR DESCRIPTION
This PR re-adds mean centering and better bias initialization for the explicit-feedback model.

However, I see that for the loss calculation, it takes a full row of all-ones in the factors into account, which should be excluded (that is, the matrix being optimized for should have 1 more row added into the regularized loss than the other).