### PR TITLE
Avoid possible errors with large matrices

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -97,10 +97,6 @@ initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lamb
     .Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative, calculate_global_bias)
 }
 
-deep_copy <- function(x) {
-    .Call(`_rsparse_deep_copy`, x)
-}
-
 rankmf_solver_double <- function(x_r, W, H, W2_grad, H2_grad, user_features_r, item_features_r, rank, n_updates, learning_rate = 0.01, gamma = 1, lambda_user = 0.0, lambda_item_positive = 0.0, lambda_item_negative = 0.0, n_threads = 1L, update_items = TRUE, loss = 0L, kernel = 0L, max_negative_samples = 50L, margin = 0.1, optimizer = 0L, report_progress = 10L) {
     invisible(.Call(`_rsparse_rankmf_solver_double`, x_r, W, H, W2_grad, H2_grad, user_features_r, item_features_r, rank, n_updates, learning_rate, gamma, lambda_user, lambda_item_positive, lambda_item_negative, n_threads, update_items, loss, kernel, max_negative_samples, margin, optimizer, report_progress))
 }
@@ -127,5 +123,13 @@ omp_thread_count <- function() {
 
 cpp_make_sparse_approximation <- function(mat_template, X, Y, sparse_matrix_type, n_threads) {
     .Call(`_rsparse_cpp_make_sparse_approximation`, mat_template, X, Y, sparse_matrix_type, n_threads)
+}
+
+large_rand_matrix <- function(nrow, ncol) {
+    .Call(`_rsparse_large_rand_matrix`, nrow, ncol)
+}
+
+deep_copy <- function(x) {
+    .Call(`_rsparse_deep_copy`, x)
 }
 

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -183,11 +183,7 @@ WRMF = R6::R6Class(
 
       logger$trace("initializing U")
       if (private$precision == "double") {
-        private$U = matrix(
-          rnorm(n_user * private$rank, 0, 0.01),
-          ncol = n_user,
-          nrow = private$rank
-        )
+        private$U = large_rand_matrix(private$rank, n_user)
         # for item biases
         if (private$with_user_item_bias) {
           private$U[1, ] = rep(1.0, n_user)
@@ -201,11 +197,7 @@ WRMF = R6::R6Class(
 
       if (is.null(self$components)) {
         if (private$precision == "double") {
-          self$components = matrix(
-            rnorm(n_item * private$rank, 0, 0.01),
-            ncol = n_item,
-            nrow = private$rank
-          )
+          self$components = large_rand_matrix(private$rank, n_item)
           # for user biases
           if (private$with_user_item_bias) {
             self$components[private$rank, ] = rep(1.0, n_item)
@@ -234,7 +226,7 @@ WRMF = R6::R6Class(
       if (private$with_user_item_bias) {
         logger$debug("initializing biases")
         # copy only c_ui@x
-        # beacause c_iu is internal
+        # because c_iu is internal
         if (private$feedback == "explicit" && private$with_global_bias)
           c_ui@x = deep_copy(c_ui@x)
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -355,17 +355,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// deep_copy
-SEXP deep_copy(SEXP x);
-RcppExport SEXP _rsparse_deep_copy(SEXP xSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< SEXP >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(deep_copy(x));
-    return rcpp_result_gen;
-END_RCPP
-}
 // rankmf_solver_double
 void rankmf_solver_double(const Rcpp::S4& x_r, arma::Mat<double>& W, arma::Mat<double>& H, arma::Col<double>& W2_grad, arma::Col<double>& H2_grad, const Rcpp::S4& user_features_r, const Rcpp::S4& item_features_r, const arma::uword rank, const arma::uword n_updates, double learning_rate, double gamma, double lambda_user, double lambda_item_positive, double lambda_item_negative, const arma::uword n_threads, bool update_items, const arma::uword loss, const arma::uword kernel, arma::uword max_negative_samples, double margin, const arma::uword optimizer, const arma::uword report_progress);
 RcppExport SEXP _rsparse_rankmf_solver_double(SEXP x_rSEXP, SEXP WSEXP, SEXP HSEXP, SEXP W2_gradSEXP, SEXP H2_gradSEXP, SEXP user_features_rSEXP, SEXP item_features_rSEXP, SEXP rankSEXP, SEXP n_updatesSEXP, SEXP learning_rateSEXP, SEXP gammaSEXP, SEXP lambda_userSEXP, SEXP lambda_item_positiveSEXP, SEXP lambda_item_negativeSEXP, SEXP n_threadsSEXP, SEXP update_itemsSEXP, SEXP lossSEXP, SEXP kernelSEXP, SEXP max_negative_samplesSEXP, SEXP marginSEXP, SEXP optimizerSEXP, SEXP report_progressSEXP) {
@@ -499,6 +488,29 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// large_rand_matrix
+SEXP large_rand_matrix(SEXP nrow, SEXP ncol);
+RcppExport SEXP _rsparse_large_rand_matrix(SEXP nrowSEXP, SEXP ncolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type nrow(nrowSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type ncol(ncolSEXP);
+    rcpp_result_gen = Rcpp::wrap(large_rand_matrix(nrow, ncol));
+    return rcpp_result_gen;
+END_RCPP
+}
+// deep_copy
+SEXP deep_copy(SEXP x);
+RcppExport SEXP _rsparse_deep_copy(SEXP xSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type x(xSEXP);
+    rcpp_result_gen = Rcpp::wrap(deep_copy(x));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_check_is_seq", (DL_FUNC) &_rsparse_check_is_seq, 1},
@@ -525,7 +537,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 9},
     {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 7},
     {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 7},
-    {"_rsparse_deep_copy", (DL_FUNC) &_rsparse_deep_copy, 1},
     {"_rsparse_rankmf_solver_double", (DL_FUNC) &_rsparse_rankmf_solver_double, 22},
     {"_rsparse_rankmf_solver_float", (DL_FUNC) &_rsparse_rankmf_solver_float, 22},
     {"_rsparse_top_product", (DL_FUNC) &_rsparse_top_product, 7},
@@ -533,6 +544,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_c_nnls_double", (DL_FUNC) &_rsparse_c_nnls_double, 4},
     {"_rsparse_omp_thread_count", (DL_FUNC) &_rsparse_omp_thread_count, 0},
     {"_rsparse_cpp_make_sparse_approximation", (DL_FUNC) &_rsparse_cpp_make_sparse_approximation, 5},
+    {"_rsparse_large_rand_matrix", (DL_FUNC) &_rsparse_large_rand_matrix, 2},
+    {"_rsparse_deep_copy", (DL_FUNC) &_rsparse_deep_copy, 1},
     {NULL, NULL, 0}
 };
 

--- a/src/SolverAlsWrmf.cpp
+++ b/src/SolverAlsWrmf.cpp
@@ -403,12 +403,3 @@ double initialize_biases_float(const Rcpp::S4 &m_csc_r,
                                   non_negative,
                                   calculate_global_bias);
 }
-
-// [[Rcpp::export]]
-SEXP deep_copy(SEXP x) {
-  SEXP out = PROTECT(Rf_allocVector(REALSXP, Rf_xlength(x)));
-  if (Rf_xlength(x))
-    memcpy(REAL(out), REAL(x), (size_t)Rf_xlength(x)*sizeof(double));
-  UNPROTECT(1);
-  return out;
-}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -125,3 +125,30 @@ arma::fvec exctract_float_vector(Rcpp::S4 x) {
   arma::fvec x_mapped = arma::fvec(ptr, x_data.length(), false, true);
   return (x_mapped);
 }
+
+// [[Rcpp::export]]
+SEXP large_rand_matrix(SEXP nrow, SEXP ncol)
+{
+  int nrow_int = Rf_asInteger(nrow);
+  int ncol_int = Rf_asInteger(ncol);
+  R_xlen_t tot_size = (R_xlen_t)nrow_int * (R_xlen_t)ncol_int;
+  if (tot_size <= 0 || nrow_int <= 0 || ncol_int <= 0)
+    Rf_error("Factors dimensions exceed R limits.");
+  SEXP vec = PROTECT(Rf_allocMatrix(REALSXP, nrow_int, ncol_int));
+  double *ptr_vec = REAL(vec);
+  for (R_xlen_t ix = 0; ix < tot_size; ix++)
+    ptr_vec[ix] = norm_rand();
+  for (R_xlen_t ix = 0; ix < tot_size; ix++)
+    ptr_vec[ix] /= 100.;
+  UNPROTECT(1);
+  return vec;
+}
+
+// [[Rcpp::export]]
+SEXP deep_copy(SEXP x) {
+  SEXP out = PROTECT(Rf_allocVector(REALSXP, Rf_xlength(x)));
+  if (Rf_xlength(x))
+    memcpy(REAL(out), REAL(x), (size_t)Rf_xlength(x)*sizeof(double));
+  UNPROTECT(1);
+  return out;
+}


### PR DESCRIPTION
When initializing the factor matrices, if the number of entries is above `INT_MAX`, the number of entries will be treated as a floating point number, which at that range will have a precision of less than integer, and as such might leave some factors as zeros. This PR avoids it by first allocating a matrix with the right dimensions and then filling it element-by-element in C++, which allows iterating with integer types larger than R's.