### PR TITLE
Add dynamic regularization

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -81,20 +81,20 @@ als_implicit_float <- function(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver,
     .Call(`_rsparse_als_implicit_float`, m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, is_x_bias_last_row)
 }
 
-als_explicit_double <- function(m_csc_r, X, Y, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row) {
-    .Call(`_rsparse_als_explicit_double`, m_csc_r, X, Y, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row)
+als_explicit_double <- function(m_csc_r, X, Y, cnt_X, lambda, n_threads, solver, cg_steps, dynamic_lambda, with_biases, is_x_bias_last_row) {
+    .Call(`_rsparse_als_explicit_double`, m_csc_r, X, Y, cnt_X, lambda, n_threads, solver, cg_steps, dynamic_lambda, with_biases, is_x_bias_last_row)
 }
 
-als_explicit_float <- function(m_csc_r, X_, Y_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row) {
-    .Call(`_rsparse_als_explicit_float`, m_csc_r, X_, Y_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row)
+als_explicit_float <- function(m_csc_r, X_, Y_, cnt_X_, lambda, n_threads, solver, cg_steps, dynamic_lambda, with_biases, is_x_bias_last_row) {
+    .Call(`_rsparse_als_explicit_float`, m_csc_r, X_, Y_, cnt_X_, lambda, n_threads, solver, cg_steps, dynamic_lambda, with_biases, is_x_bias_last_row)
 }
 
-initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative, calculate_global_bias = FALSE) {
-    .Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative, calculate_global_bias)
+initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE) {
+    .Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias)
 }
 
-initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative, calculate_global_bias = FALSE) {
-    .Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative, calculate_global_bias)
+initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE) {
+    .Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias)
 }
 
 deep_copy <- function(x) {

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -20,6 +20,10 @@
 #'         non-negative least squares problem."
 #'         International Conference on Computer Analysis of Images
 #'         and Patterns. Springer, Berlin, Heidelberg, 2005.}
+#'   \item{Zhou, Yunhong, et al.
+#'         "Large-scale parallel collaborative filtering for the netflix prize."
+#'         International conference on algorithmic applications in management.
+#'         Springer, Berlin, Heidelberg, 2008.}
 #' }
 #' @export
 #' @examples
@@ -38,6 +42,8 @@ WRMF = R6::R6Class(
     #' @description creates WRMF model
     #' @param rank size of the latent dimension
     #' @param lambda regularization parameter
+    #' @param dynamic_lambda whether `lambda` is to be scaled according to the number
+    #  of non-missing entries for each row/column (only applicable to the explicit-feedback model).
     #' @param init initialization of item embeddings
     #' @param preprocess \code{identity()} by default. User spectified function which will
     #' be applied to user-item interaction matrix before running matrix factorization
@@ -67,6 +73,7 @@ WRMF = R6::R6Class(
     #' @param ... not used at the moment
     initialize = function(rank = 10L,
                           lambda = 0,
+                          dynamic_lambda = TRUE,
                           init = NULL,
                           preprocess = identity,
                           feedback = c("implicit", "explicit"),
@@ -100,13 +107,21 @@ WRMF = R6::R6Class(
       private$precision = match.arg(precision)
       private$feedback = feedback
       private$lambda = as.numeric(lambda)
+      private$dynamic_lambda = as.logical(dynamic_lambda)[1L]
 
       stopifnot(is.integer(cg_steps) && length(cg_steps) == 1)
       private$cg_steps = cg_steps
 
       n_threads = getOption("rsparse_omp_threads", 1L)
-      private$solver = function(x, X, Y, is_bias_last_row, XtX = NULL, avoid_cg = FALSE) {
+      private$solver = function(x, X, Y, is_bias_last_row, XtX = NULL, cnt_X=NULL, avoid_cg = FALSE) {
         solver_use = ifelse(avoid_cg && private$solver_code == 1L, 0L, private$solver_code)
+        if (private$lambda && dynamic_lambda && is.null(cnt_X)) {
+          if (private$precision == "double") {
+            cnt_X = numeric(ncol(X))
+          } else {
+            cnt_X = float::float(ncol(X))
+          }
+        }
         if(feedback == "implicit") {
           als_implicit(
             x, X, Y,
@@ -120,11 +135,12 @@ WRMF = R6::R6Class(
             XtX = XtX)
         } else {
           als_explicit(
-            x, X, Y,
+            x, X, Y, cnt_X,
             lambda = private$lambda,
             n_threads = n_threads,
             solver_code = solver_use,
             cg_steps = private$cg_steps,
+            dynamic_lambda = private$dynamic_lambda,
             precision = private$precision,
             with_user_item_bias = private$with_user_item_bias,
             is_bias_last_row = is_bias_last_row)
@@ -136,7 +152,7 @@ WRMF = R6::R6Class(
         FUN = ifelse(private$precision == 'double',
                      initialize_biases_double,
                      initialize_biases_float)
-        FUN(c_ui, c_iu, user_bias, item_bias, private$lambda,
+        FUN(c_ui, c_iu, user_bias, item_bias, private$lambda, private$dynamic_lambda,
             private$non_negative, private$with_global_bias)
       }
 
@@ -260,12 +276,25 @@ WRMF = R6::R6Class(
 
       loss_prev_iter = Inf
 
+      # for dynamic lambda, need to keep track of the number of entries
+      # in order to calculate the regularized loss
+      cnt_u = numeric()
+      cnt_i = numeric()
+      if (private$dynamic_lambda) {
+        cnt_u = as.numeric(diff(c_ui@p))
+        cnt_i = as.numeric(diff(c_iu@p))
+      }
+      if (private$precision == "float") {
+        cnt_u = float::fl(cnt_u)
+        cnt_i = float::fl(cnt_i)
+      }
+
       # iterate
       for (i in seq_len(n_iter)) {
         # solve for items
-        loss = private$solver(c_ui, private$U, self$components, TRUE)
+        loss = private$solver(c_ui, private$U, self$components, TRUE, cnt_X=cnt_i)
         # solve for users
-        loss = private$solver(c_iu, self$components, private$U, FALSE)
+        loss = private$solver(c_iu, self$components, private$U, FALSE, cnt_X=cnt_u)
 
         logger$info("iter %d loss = %.4f", i, loss)
         if (loss_prev_iter / loss - 1 < convergence_tol) {
@@ -323,7 +352,7 @@ WRMF = R6::R6Class(
         res = float(0, nrow = private$rank, ncol = nrow(x))
       }
 
-      loss = private$solver(t(x), self$components, res, FALSE, private$XtX, TRUE)
+      loss = private$solver(t(x), self$components, res, FALSE, private$XtX, avoid_cg=TRUE)
 
       res = t(res)
 
@@ -341,6 +370,7 @@ WRMF = R6::R6Class(
     cg_steps = NULL,
     scorers = NULL,
     lambda = NULL,
+    dynamic_lambda = FALSE,
     rank = NULL,
     non_negative = NULL,
     # user factor matrix = rank * n_users
@@ -392,11 +422,12 @@ als_implicit = function(
 }
 
 als_explicit = function(
-  x, X, Y, XtX,
+  x, X, Y, cnt_X,
   lambda,
   n_threads,
   solver_code,
   cg_steps,
+  dynamic_lambda,
   precision,
   with_user_item_bias,
   is_bias_last_row) {
@@ -406,7 +437,7 @@ als_explicit = function(
                   als_explicit_double)
 
   # Y is modified in-place
-  loss = solver(x, X, Y, lambda, n_threads, solver_code, cg_steps, with_user_item_bias, is_bias_last_row)
+  loss = solver(x, X, Y, cnt_X, lambda, n_threads, solver_code, cg_steps, dynamic_lambda, with_user_item_bias, is_bias_last_row)
 }
 
 solver_explicit = function(x, X, Y, lambda = 0, non_negative = FALSE) {

--- a/man/WRMF.Rd
+++ b/man/WRMF.Rd
@@ -35,6 +35,10 @@ preds = model$predict(cv, k = 10, not_recommend = cv)
         non-negative least squares problem."
         International Conference on Computer Analysis of Images
         and Patterns. Springer, Berlin, Heidelberg, 2005.}
+  \item{Zhou, Yunhong, et al.
+        "Large-scale parallel collaborative filtering for the netflix prize."
+        International conference on algorithmic applications in management.
+        Springer, Berlin, Heidelberg, 2008.}
 }
 }
 \section{Super class}{
@@ -65,6 +69,7 @@ creates WRMF model
 \if{html}{\out{<div class="r">}}\preformatted{WRMF$new(
   rank = 10L,
   lambda = 0,
+  dynamic_lambda = TRUE,
   init = NULL,
   preprocess = identity,
   feedback = c("implicit", "explicit"),
@@ -83,6 +88,8 @@ creates WRMF model
 \item{\code{rank}}{size of the latent dimension}
 
 \item{\code{lambda}}{regularization parameter}
+
+\item{\code{dynamic_lambda}}{whether `lambda` is to be scaled according to the number}
 
 \item{\code{init}}{initialization of item embeddings}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -284,46 +284,50 @@ BEGIN_RCPP
 END_RCPP
 }
 // als_explicit_double
-double als_explicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, const bool with_biases, bool is_x_bias_last_row);
-RcppExport SEXP _rsparse_als_explicit_double(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP) {
+double als_explicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, arma::Col<double> cnt_X, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, const bool dynamic_lambda, const bool with_biases, bool is_x_bias_last_row);
+RcppExport SEXP _rsparse_als_explicit_double(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP cnt_XSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP dynamic_lambdaSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
     Rcpp::traits::input_parameter< arma::mat& >::type X(XSEXP);
     Rcpp::traits::input_parameter< arma::mat& >::type Y(YSEXP);
+    Rcpp::traits::input_parameter< arma::Col<double> >::type cnt_X(cnt_XSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
     Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< const bool >::type dynamic_lambda(dynamic_lambdaSEXP);
     Rcpp::traits::input_parameter< const bool >::type with_biases(with_biasesSEXP);
     Rcpp::traits::input_parameter< bool >::type is_x_bias_last_row(is_x_bias_last_rowSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_explicit_double(m_csc_r, X, Y, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row));
+    rcpp_result_gen = Rcpp::wrap(als_explicit_double(m_csc_r, X, Y, cnt_X, lambda, n_threads, solver, cg_steps, dynamic_lambda, with_biases, is_x_bias_last_row));
     return rcpp_result_gen;
 END_RCPP
 }
 // als_explicit_float
-double als_explicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& X_, Rcpp::S4& Y_, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, const bool with_biases, bool is_x_bias_last_row);
-RcppExport SEXP _rsparse_als_explicit_float(SEXP m_csc_rSEXP, SEXP X_SEXP, SEXP Y_SEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP) {
+double als_explicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& X_, Rcpp::S4& Y_, Rcpp::S4& cnt_X_, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, const bool dynamic_lambda, const bool with_biases, bool is_x_bias_last_row);
+RcppExport SEXP _rsparse_als_explicit_float(SEXP m_csc_rSEXP, SEXP X_SEXP, SEXP Y_SEXP, SEXP cnt_X_SEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP dynamic_lambdaSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::S4& >::type m_csc_r(m_csc_rSEXP);
     Rcpp::traits::input_parameter< Rcpp::S4& >::type X_(X_SEXP);
     Rcpp::traits::input_parameter< Rcpp::S4& >::type Y_(Y_SEXP);
+    Rcpp::traits::input_parameter< Rcpp::S4& >::type cnt_X_(cnt_X_SEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
     Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< const bool >::type dynamic_lambda(dynamic_lambdaSEXP);
     Rcpp::traits::input_parameter< const bool >::type with_biases(with_biasesSEXP);
     Rcpp::traits::input_parameter< bool >::type is_x_bias_last_row(is_x_bias_last_rowSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_explicit_float(m_csc_r, X_, Y_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row));
+    rcpp_result_gen = Rcpp::wrap(als_explicit_float(m_csc_r, X_, Y_, cnt_X_, lambda, n_threads, solver, cg_steps, dynamic_lambda, with_biases, is_x_bias_last_row));
     return rcpp_result_gen;
 END_RCPP
 }
 // initialize_biases_double
-double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool non_negative, bool calculate_global_bias);
-RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP) {
+double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias);
+RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -332,15 +336,16 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::Col<double>& >::type user_bias(user_biasSEXP);
     Rcpp::traits::input_parameter< arma::Col<double>& >::type item_bias(item_biasSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< bool >::type dynamic_lambda(dynamic_lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
     Rcpp::traits::input_parameter< bool >::type calculate_global_bias(calculate_global_biasSEXP);
-    rcpp_result_gen = Rcpp::wrap(initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative, calculate_global_bias));
+    rcpp_result_gen = Rcpp::wrap(initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias));
     return rcpp_result_gen;
 END_RCPP
 }
 // initialize_biases_float
-double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool non_negative, bool calculate_global_bias);
-RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP) {
+double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias);
+RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -349,9 +354,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::S4& >::type user_bias(user_biasSEXP);
     Rcpp::traits::input_parameter< Rcpp::S4& >::type item_bias(item_biasSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
+    Rcpp::traits::input_parameter< bool >::type dynamic_lambda(dynamic_lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
     Rcpp::traits::input_parameter< bool >::type calculate_global_bias(calculate_global_biasSEXP);
-    rcpp_result_gen = Rcpp::wrap(initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, non_negative, calculate_global_bias));
+    rcpp_result_gen = Rcpp::wrap(initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -521,10 +527,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_dense_csc_prod", (DL_FUNC) &_rsparse_dense_csc_prod, 3},
     {"_rsparse_als_implicit_double", (DL_FUNC) &_rsparse_als_implicit_double, 9},
     {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 9},
-    {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 9},
-    {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 9},
-    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 7},
-    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 7},
+    {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 11},
+    {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 11},
+    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 8},
+    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 8},
     {"_rsparse_deep_copy", (DL_FUNC) &_rsparse_deep_copy, 1},
     {"_rsparse_rankmf_solver_double", (DL_FUNC) &_rsparse_rankmf_solver_double, 22},
     {"_rsparse_rankmf_solver_float", (DL_FUNC) &_rsparse_rankmf_solver_float, 22},

--- a/src/rsparse.h
+++ b/src/rsparse.h
@@ -17,8 +17,8 @@
 
 dMappedCSR extract_mapped_csr(Rcpp::S4 input);
 dMappedCSC extract_mapped_csc(Rcpp::S4 input);
-arma::fmat exctract_float_matrix(Rcpp::S4 x);
-arma::fvec exctract_float_vector(Rcpp::S4 x);
+arma::fmat extract_float_matrix(Rcpp::S4 x);
+arma::fvec extract_float_vector(Rcpp::S4 x);
 // [[Rcpp::export]]
 int omp_thread_count();
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -112,14 +112,14 @@ const std::string currentDateTime() {
   return buf;
 }
 
-arma::fmat exctract_float_matrix(Rcpp::S4 x) {
+arma::fmat extract_float_matrix(Rcpp::S4 x) {
   Rcpp::IntegerMatrix x_data = x.slot("Data");
   float *ptr = reinterpret_cast<float *>(&x_data[0]);
   arma::fmat x_mapped = arma::fmat(ptr, x_data.nrow(), x_data.ncol(), false, true);
   return (x_mapped);
 }
 
-arma::fvec exctract_float_vector(Rcpp::S4 x) {
+arma::fvec extract_float_vector(Rcpp::S4 x) {
   Rcpp::IntegerVector x_data = x.slot("Data");
   float *ptr = reinterpret_cast<float *>(&x_data[0]);
   arma::fvec x_mapped = arma::fvec(ptr, x_data.length(), false, true);


### PR DESCRIPTION
This PR adds an option in the explicit feedback model for having the regularization parameter scale with the number of non-missing entries per user/item. This tends to result in better predictions on new data, and tends to be the default way of taking the regularization in other software (e.g. lenskit, libmf).