### PR TITLE
initial work on biases for model with implicit feedback

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,12 +73,12 @@ dense_csc_prod <- function(x_r, y_csc_r, num_threads = 1L) {
     .Call(`_rsparse_dense_csc_prod`, x_r, y_csc_r, num_threads)
 }
 
-als_implicit_double <- function(m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, is_x_bias_last_row) {
-    .Call(`_rsparse_als_implicit_double`, m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, is_x_bias_last_row)
+als_implicit_double <- function(m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row) {
+    .Call(`_rsparse_als_implicit_double`, m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row)
 }
 
-als_implicit_float <- function(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, is_x_bias_last_row) {
-    .Call(`_rsparse_als_implicit_float`, m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, is_x_bias_last_row)
+als_implicit_float <- function(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row) {
+    .Call(`_rsparse_als_implicit_float`, m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row)
 }
 
 als_explicit_double <- function(m_csc_r, X, Y, cnt_X, lambda, n_threads, solver, cg_steps, dynamic_lambda, with_biases, is_x_bias_last_row) {

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -358,6 +358,10 @@ WRMF = R6::R6Class(
         res = float(0, nrow = private$rank, ncol = nrow(x))
       }
 
+      if (private$with_user_item_bias) {
+        res[1, ] = ifelse(private$precision == "double", 1.0, float::fl(1.0))
+      }
+
       loss = private$solver(
         t(x),
         self$components,

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -359,7 +359,7 @@ WRMF = R6::R6Class(
       }
 
       if (private$with_user_item_bias) {
-        res[1, ] = ifelse(private$precision == "double", 1.0, float::fl(1.0))
+        res[1, ] = if(private$precision == "double") 1.0 else float::fl(1.0)
       }
 
       loss = private$solver(

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -246,8 +246,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // als_implicit_double
-double als_implicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, const arma::mat& XtX, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, bool is_x_bias_last_row);
-RcppExport SEXP _rsparse_als_implicit_double(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP XtXSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP is_x_bias_last_rowSEXP) {
+double als_implicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, const arma::mat& XtX, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, const bool with_biases, bool is_x_bias_last_row);
+RcppExport SEXP _rsparse_als_implicit_double(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP XtXSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -259,14 +259,15 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
     Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< const bool >::type with_biases(with_biasesSEXP);
     Rcpp::traits::input_parameter< bool >::type is_x_bias_last_row(is_x_bias_last_rowSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_implicit_double(m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, is_x_bias_last_row));
+    rcpp_result_gen = Rcpp::wrap(als_implicit_double(m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row));
     return rcpp_result_gen;
 END_RCPP
 }
 // als_implicit_float
-double als_implicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& X_, Rcpp::S4& Y_, Rcpp::S4& XtX_, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, bool is_x_bias_last_row);
-RcppExport SEXP _rsparse_als_implicit_float(SEXP m_csc_rSEXP, SEXP X_SEXP, SEXP Y_SEXP, SEXP XtX_SEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP is_x_bias_last_rowSEXP) {
+double als_implicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& X_, Rcpp::S4& Y_, Rcpp::S4& XtX_, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, const bool with_biases, bool is_x_bias_last_row);
+RcppExport SEXP _rsparse_als_implicit_float(SEXP m_csc_rSEXP, SEXP X_SEXP, SEXP Y_SEXP, SEXP XtX_SEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -278,8 +279,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
     Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
     Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< const bool >::type with_biases(with_biasesSEXP);
     Rcpp::traits::input_parameter< bool >::type is_x_bias_last_row(is_x_bias_last_rowSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_implicit_float(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, is_x_bias_last_row));
+    rcpp_result_gen = Rcpp::wrap(als_implicit_float(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -538,8 +540,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_cpp_glove_partial_fit", (DL_FUNC) &_rsparse_cpp_glove_partial_fit, 6},
     {"_rsparse_csr_dense_tcrossprod", (DL_FUNC) &_rsparse_csr_dense_tcrossprod, 3},
     {"_rsparse_dense_csc_prod", (DL_FUNC) &_rsparse_dense_csc_prod, 3},
-    {"_rsparse_als_implicit_double", (DL_FUNC) &_rsparse_als_implicit_double, 9},
-    {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 9},
+    {"_rsparse_als_implicit_double", (DL_FUNC) &_rsparse_als_implicit_double, 10},
+    {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 10},
     {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 11},
     {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 11},
     {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 8},

--- a/src/SolverAlsWrmf.cpp
+++ b/src/SolverAlsWrmf.cpp
@@ -124,7 +124,7 @@ T als_explicit(const dMappedCSC& Conf,
     // catch situation when some columns in matrix are empty,
     // so p1 becomes equal to p2 or greater than number of columns
     if(p1 < p2) {
-      auto idx = arma::uvec(&Conf.row_indices[p1], p2 - p1, false, true);
+      const arma::uvec idx = arma::uvec(&Conf.row_indices[p1], p2 - p1, false, true);
       T lambda_use = lambda * (dynamic_lambda? static_cast<T>(p2-p1) : 1.);
       arma::Col<T> confidence = arma::conv_to< arma::Col<T> >::from(arma::vec(&Conf.values[p1], p2 - p1));
       arma::Mat<T> X_nnz = X.cols(idx);
@@ -202,10 +202,7 @@ T als_explicit(const dMappedCSC& Conf,
       // X = [1, ..., x_bias]
       // Y = [y_bias, ..., 1]
       bool is_drop_last_x = !is_x_bias_last_row;
-      bool is_drop_last_y = is_x_bias_last_row;
-      auto X_excl_ones = drop_row<T>(X, is_drop_last_x);
-      auto Y_excl_ones = drop_row<T>(Y, is_drop_last_y);
-      // accu(X_excl_ones % X_excl_ones)
+      const arma::Mat<T> X_excl_ones = drop_row<T>(X, is_drop_last_x);
       // as per arma docs "multiply-and-accumulate"
       // should should be translated
       // into efficient MKL/OpenBLAS calls
@@ -248,12 +245,45 @@ T als_implicit(const dMappedCSC& Conf,
   const arma::uword rank = X.n_rows;
 
   arma::Col<T> x_biases;
+  arma::Mat<T> rhs_init;
 
   if (with_biases) {
     if (is_x_bias_last_row) // last row
-      x_biases = X.row(X.n_rows - 1).t();
+      x_biases = X.row(X.n_rows - 1).t() ;
     else // first row
       x_biases = X.row(0).t();
+
+    // if we model bias then `rhs = X * C_u * (p_u - x_biases)`
+    // where
+    // X - item embeddings matrix
+    // `C_u` is a diagonal matrix of confidences (n_item*n_item)
+    // C_u has a form: `C_ui = 1 + f(r_ui)`
+    // For missing entries C_u = 1
+    // `p` is an indicator function:
+    // - 0 if user-item interaction missing
+    // - 1 if user-item interaction is present
+
+    // we can rewrite it as
+    // rhs = X * 1 * (0 - x_biases) + X * (1 + f(r_ui)) * (1 - x_biases)
+
+    // we know that most of the interactions are missing (p=0)
+    // so we can pre-compute `rhs_init` for all p=0:
+    // `rhs_init = X * 1 * (0 - x_biases)`
+    //
+    // and then for each user we can calculate `rhs` using
+    // small a update from`rhs_init`.
+    // For non-missing interactions (p=1)
+    // rhs_user = rhs_init - \
+    //    X_nnz_user * 1 * (0 - x_biases_nnz_user) +
+    //    X_nnz_user * C_nnz_user * (1 - x_biases_nnz_user)
+
+    // here we do following:
+    // drop row with "ones" placeholder for convenient ALS form
+    rhs_init = drop_row<T>(X, is_x_bias_last_row);
+    // p = 0
+    // C = 1 (so we omit multiplication on eye matrix)
+    // rhs = X * eye * (0 - x_biases) = -X * x_biases
+    rhs_init *= -x_biases;
   }
 
   T loss = 0;
@@ -266,7 +296,7 @@ T als_implicit(const dMappedCSC& Conf,
     arma::uword p2 = Conf.col_ptrs[i + 1];
     // catch situation when some columns in matrix are empty, so p1 becomes equal to p2 or greater than number of columns
     if(p1 < p2) {
-      auto idx = arma::uvec(&Conf.row_indices[p1], p2 - p1, false, true);
+      const arma::uvec idx = arma::uvec(&Conf.row_indices[p1], p2 - p1, false, true);
       arma::Col<T> confidence = arma::conv_to< arma::Col<T> >::from(arma::vec(&Conf.values[p1], p2 - p1));
       arma::Mat<T> X_nnz = X.cols(idx);
       arma::Col<T> init = Y.col(i);
@@ -276,7 +306,6 @@ T als_implicit(const dMappedCSC& Conf,
       // X_nnz = [..., 1]
       if (with_biases) {
         X_nnz = drop_row<T>(X_nnz, is_x_bias_last_row);
-        confidence -= x_biases(idx);
         init = drop_row<T>(init, !is_x_bias_last_row);
       }
       arma::Col<T> Y_new;
@@ -285,7 +314,27 @@ T als_implicit(const dMappedCSC& Conf,
         Y_new = cg_solver_implicit<T>(X_nnz, confidence, init, cg_steps, XtX);
       } else {
         const arma::Mat<T> lhs = XtX + X_nnz.each_row() % (confidence.t() - 1) * X_nnz.t();
-        const arma::Mat<T> rhs = X_nnz * confidence;
+        arma::Mat<T> rhs;
+        if (with_biases) {
+          // now we need to update rhs with rhs_init and take into account
+          // items with interactions (p=1)
+
+          // first we reset contributions from items
+          // where we considered p=0, but actually p=1 during rhs_init calculation
+
+          // rhs = rhs_init + X_nnz * x_biases(idx); // rhs_init - (X_nnz * (0 - x_biases(idx)))
+          // // element-wise row multiplication is equal
+          // // to multiplying on diagonal matrix
+          // rhs += (X_nnz.each_row() % confidence.t()) * \
+          //       // mult by (1 - biases)
+          //       (1 - x_biases(idx));
+
+          // expression above can be simplified further:
+          rhs = rhs_init + X_nnz * (confidence - x_biases(idx) % (confidence - 1));
+
+        } else {
+          rhs = X_nnz * confidence;
+        }
         if (solver == SEQ_COORDINATE_WISE_NNLS) {
           Y_new = c_nnls<T>(lhs, rhs, init, SCD_MAX_ITER, SCD_TOL);
         } else { // CHOLESKY
@@ -310,7 +359,8 @@ T als_implicit(const dMappedCSC& Conf,
         Y.unsafe_col(i) = Y_new;
       }
 
-      loss += dot(square( 1 - (Y_new.t() * X_nnz)), confidence);
+      loss += dot(square( 1 - (Y_new.t() * X_nnz)), confidence) +
+        lambda * arma::dot(Y_new, Y_new);
 
     } else {
       if (with_biases) {
@@ -327,7 +377,22 @@ T als_implicit(const dMappedCSC& Conf,
   }
 
   if(lambda > 0) {
-    loss += lambda * (accu(X % X) + accu(Y % Y));
+    if (with_biases) {
+      // lambda applied to all learned parameters:
+      // embeddings and biases
+      // so we select all rows excluding dummy ones
+      // if is_x_bias_last_row == true
+      // X = [1, ..., x_bias]
+      // Y = [y_bias, ..., 1]
+      bool is_drop_last_x = !is_x_bias_last_row;
+      const arma::Mat<T> X_excl_ones = drop_row<T>(X, is_drop_last_x);
+      // as per arma docs "multiply-and-accumulate"
+      // should should be translated
+      // into efficient MKL/OpenBLAS calls
+      loss += lambda * accu(X_excl_ones % X_excl_ones);
+    } else {
+      loss += lambda * accu(X % X);
+    }
   }
   return (loss / Conf.nnz);
 }


### PR DESCRIPTION
related to #53 

> INFO  [17:41:35.834] starting factorization with 8 threads 
INFO  [17:41:37.072] iter 1 (items) loss = 3.7734 
INFO  [17:41:37.481] iter 1 (users) loss = 4.0005 
INFO  [17:41:38.686] iter 2 (items) loss = 3.0621 
INFO  [17:41:39.094] iter 2 (users) loss = 3.0296 
INFO  [17:41:40.301] iter 3 (items) loss = 2.8185 
INFO  [17:41:40.701] iter 3 (users) loss = 2.9594 
INFO  [17:41:41.924] iter 4 (items) loss = 2.8183 
INFO  [17:41:42.327] iter 4 (users) loss = 2.9471 
INFO  [17:41:43.584] iter 5 (items) loss = 2.8426 
INFO  [17:41:43.994] iter 5 (users) loss = 2.9721 

- loss doesn't decrease monotonically anymore (strange!)
- on lastfm360k model with biases shows worse map@k compared to the model without biases (which strange as model is more expressive)
- item bias is highly correlated with item popularity (> 0.8 spearman correlation ) (as expected)

cc @david-cortes 