### PR TITLE
Update to new Matrix syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ LazyData: true
 ByteCompile: true
 Depends: R (>= 3.6.0), methods
 Imports: 
-    Matrix (>= 1.2), 
+    Matrix (>= 1.3), 
     Rcpp (>= 0.11),
     data.table (>= 1.10.0),
     float (>= 0.2-2),

--- a/R/model_FTRL.R
+++ b/R/model_FTRL.R
@@ -11,8 +11,7 @@
 #' x = sample(c(-1, 1), 1000 * 100, TRUE)
 #' odd = seq(1, 99, 2)
 #' x[i %in% which(y == 1) & j %in% odd] = 1
-#' m = sparseMatrix(i = i, j = j, x = x, dims = c(1000, 1000), giveCsparse = FALSE)
-#' x = as(m, "RsparseMatrix")
+#' x = sparseMatrix(i = i, j = j, x = x, dims = c(1000, 1000), repr="R")
 #'
 #' ftrl = FTRL$new(learning_rate = 0.01, learning_rate_decay = 0.1,
 #' lambda = 10, l1_ratio = 1, dropout = 0)
@@ -21,7 +20,7 @@
 #' w = ftrl$coef()
 #' head(w)
 #' sum(w != 0)
-#' p = ftrl$predict(m)
+#' p = ftrl$predict(x)
 #' @export
 FTRL = R6::R6Class(
   classname = "FTRL",


### PR DESCRIPTION
The latest version of the `Matrix` package deprecated the argument `giveCsparse`, changing it instead to a `repr="C"/"R"/"T"`.

This short PR updates an example in which it was used.