### PR TITLE
Fixes for implicit biases

### DIFF
--- a/R/MatrixFactorizationRecommender.R
+++ b/R/MatrixFactorizationRecommender.R
@@ -8,6 +8,9 @@ MatrixFactorizationRecommender = R6::R6Class(
     components = NULL,
     #' @field global_bias global mean (for centering values in explicit feedback)
     global_bias = 0.,
+    #' @field global_bias_base Pre-calculated `-(factors*global_bias)` (for centering values in
+    #' implicit feedback when not using user/item biases)
+    global_bias_base = numeric(),
     #' @description recommends items for users
     #' @param x user-item interactions matrix (usually sparse - `Matrix::sparseMatrix`).Users are
     #' rows and items are columns

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -125,11 +125,11 @@ als_implicit_float <- function(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver,
     .Call(`_rsparse_als_implicit_float`, m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row, global_bias, global_bias_base_, initialize_bias_base)
 }
 
-initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE, is_explicit_feedback = FALSE) {
-    .Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback)
+initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE, is_explicit_feedback = FALSE, initialize_item_biases = FALSE) {
+    .Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback, initialize_item_biases)
 }
 
-initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE, is_explicit_feedback = FALSE) {
-    .Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback)
+initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE, is_explicit_feedback = FALSE, initialize_item_biases = FALSE) {
+    .Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback, initialize_item_biases)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -117,19 +117,19 @@ als_explicit_float <- function(m_csc_r, X_, Y_, cnt_X_, lambda, n_threads, solve
     .Call(`_rsparse_als_explicit_float`, m_csc_r, X_, Y_, cnt_X_, lambda, n_threads, solver, cg_steps, dynamic_lambda, with_biases, is_x_bias_last_row)
 }
 
-als_implicit_double <- function(m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row) {
-    .Call(`_rsparse_als_implicit_double`, m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row)
+als_implicit_double <- function(m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row, global_bias, global_bias_base, initialize_bias_base) {
+    .Call(`_rsparse_als_implicit_double`, m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row, global_bias, global_bias_base, initialize_bias_base)
 }
 
-als_implicit_float <- function(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row) {
-    .Call(`_rsparse_als_implicit_float`, m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row)
+als_implicit_float <- function(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row, global_bias, global_bias_base_, initialize_bias_base) {
+    .Call(`_rsparse_als_implicit_float`, m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row, global_bias, global_bias_base_, initialize_bias_base)
 }
 
-initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE) {
-    .Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias)
+initialize_biases_double <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE, is_explicit_feedback = FALSE) {
+    .Call(`_rsparse_initialize_biases_double`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback)
 }
 
-initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE) {
-    .Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias)
+initialize_biases_float <- function(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias = FALSE, is_explicit_feedback = FALSE) {
+    .Call(`_rsparse_initialize_biases_float`, m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback)
 }
 

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -87,18 +87,6 @@ WRMF = R6::R6Class(
       solver = match.arg(solver)
       feedback = match.arg(feedback)
 
-      if (feedback == 'implicit') {
-        # FIXME
-
-        if (solver == "conjugate_gradient" && with_user_item_bias == TRUE) {
-          msg = paste("'conjugate_gradient' is not supported for a model",
-            "`with_user_item_bias == TRUE`. Setting to 'cholesky'."
-          )
-          warning(msg)
-          solver = "cholesky"
-        }
-        with_global_bias = FALSE
-      }
       private$non_negative = ifelse(solver == "nnls", TRUE, FALSE)
 
       if (private$non_negative && with_global_bias == TRUE) {
@@ -141,7 +129,10 @@ WRMF = R6::R6Class(
             precision = private$precision,
             with_user_item_bias = private$with_user_item_bias,
             is_bias_last_row = is_bias_last_row,
-            XtX = XtX)
+            global_bias = self$global_bias,
+            initialize_bias_base = !avoid_cg,
+            XtX = XtX,
+            global_bias_base = self$global_bias_base)
         } else {
           als_explicit(
             x, X, Y, cnt_X,
@@ -162,7 +153,7 @@ WRMF = R6::R6Class(
                      initialize_biases_double,
                      initialize_biases_float)
         FUN(c_ui, c_iu, user_bias, item_bias, private$lambda, private$dynamic_lambda,
-            private$non_negative, private$with_global_bias)
+            private$non_negative, private$with_global_bias, feedback == "explicit")
       }
 
       self$components = init
@@ -211,28 +202,43 @@ WRMF = R6::R6Class(
         private$U = large_rand_matrix(private$rank, n_user)
         # for item biases
         if (private$with_user_item_bias) {
-          private$U[1, ] = rep(1.0, n_user)
+          private$U[1L, ] = rep(1.0, n_user)
         }
       } else {
         private$U = flrnorm(private$rank, n_user, 0, 0.01)
         if (private$with_user_item_bias) {
-          private$U[1, ] = float::fl(rep(1.0, n_user))
+          private$U[1L, ] = float::fl(rep(1.0, n_user))
         }
       }
 
       if (is.null(self$components)) {
-        if (private$precision == "double") {
-          self$components = large_rand_matrix(private$rank, n_item)
-          # for user biases
-          if (private$with_user_item_bias) {
-            self$components[private$rank, ] = rep(1.0, n_item)
+
+        if (private$solver_code == 1L) { ### <- cholesky
+          if (private$precision == "double") {
+            self$components = matrix(0, private$rank, n_item)
+            if (private$with_user_item_bias) {
+              self$components[private$rank, ] = rep(1.0, n_item)
+            }
+          } else {
+            self$components = float::float(0, private$rank, n_item)
+            if (private$with_user_item_bias) {
+              self$components[private$rank, ] = float::fl(rep(1.0, n_item))
+            }
           }
-        } else {
-          self$components = flrnorm(private$rank, n_item, 0, 0.01)
-          if (private$with_user_item_bias) {
-            self$components[private$rank, ] = float::fl(rep(1.0, n_item))
+          } else {
+            if (private$precision == "double") {
+              self$components = large_rand_matrix(private$rank, n_item)
+              # for user biases
+              if (private$with_user_item_bias) {
+                self$components[private$rank, ] = rep(1.0, n_item)
+              }
+            } else {
+              self$components = flrnorm(private$rank, n_item, 0, 0.01)
+              if (private$with_user_item_bias) {
+                self$components[private$rank, ] = float::fl(rep(1.0, n_item))
+              }
+            }
           }
-        }
       } else {
         stopifnot(is.matrix(self$components) || is.float(self$components))
         stopifnot(ncol(self$components) == n_item)
@@ -268,10 +274,23 @@ WRMF = R6::R6Class(
         self$components[1L, ] = item_bias
         private$U[private$rank, ] = user_bias
         if(private$with_global_bias) self$global_bias = global_bias
-      } else if (private$feedback == "explicit" && private$with_global_bias) {
-        self$global_bias = mean(c_ui@x)
-        c_ui@x = c_ui@x - self$global_bias
-        c_iu@x = c_iu@x - self$global_bias
+      } else if (private$with_global_bias) {
+        if (private$feedback == "explicit") {
+          self$global_bias = mean(c_ui@x)
+          c_ui@x = c_ui@x - self$global_bias
+          c_iu@x = c_iu@x - self$global_bias
+        } else {
+          s = sum(c_ui@x)
+          self$global_bias = s / (s + as.numeric(nrow(c_ui))*as.numeric(ncol(c_ui)) - length(c_ui@x))
+        }
+      }
+
+      if (private$feedback == "implicit") {
+        size_global_bias_base = ifelse(private$with_user_item_bias, 0L, private$rank-1L)
+        if (private$precision == "double")
+          self$global_bias_base = numeric(size_global_bias_base)
+        else
+          self$global_bias_base = float(size_global_bias_base)
       }
 
       logger$info("starting factorization with %d threads", getOption("rsparse_omp_threads", 1L))
@@ -350,7 +369,7 @@ WRMF = R6::R6Class(
 
       x = as(x, "CsparseMatrix")
       x = private$preprocess(x)
-      if (self$global_bias != 0.)
+      if (self$global_bias != 0. && private$feedback == "explicit")
         x@x = x@x - self$global_bias
 
       if (private$precision == "double") {
@@ -420,7 +439,10 @@ als_implicit = function(
   precision,
   with_user_item_bias,
   is_bias_last_row,
-  XtX = NULL) {
+  initialize_bias_base,
+  global_bias = 0.,
+  XtX = NULL,
+  global_bias_base = NULL) {
 
   solver = ifelse(precision == "float",
                   als_implicit_float,
@@ -437,8 +459,15 @@ als_implicit = function(
     }
     XtX = tcrossprod(XX) + ridge
   }
+  if (is.null(global_bias_base)) {
+    global_bias_base = numeric()
+    if (precision == "float")
+      global_bias_base = float::fl(global_bias_base)
+  }
   # Y is modified in-place
-  loss = solver(x, X, Y, XtX, lambda, n_threads, solver_code, cg_steps, with_user_item_bias, is_bias_last_row)
+  loss = solver(x, X, Y, XtX, lambda, n_threads, solver_code, cg_steps,
+                with_user_item_bias, is_bias_last_row, global_bias,
+                global_bias_base, initialize_bias_base)
 }
 
 als_explicit = function(

--- a/R/model_WRMF.R
+++ b/R/model_WRMF.R
@@ -153,7 +153,8 @@ WRMF = R6::R6Class(
                      initialize_biases_double,
                      initialize_biases_float)
         FUN(c_ui, c_iu, user_bias, item_bias, private$lambda, private$dynamic_lambda,
-            private$non_negative, private$with_global_bias, feedback == "explicit")
+            private$non_negative, private$with_global_bias, feedback == "explicit",
+            private$solver_code != 1)
       }
 
       self$components = init

--- a/inst/include/wrmf_explicit.hpp
+++ b/inst/include/wrmf_explicit.hpp
@@ -32,8 +32,8 @@ arma::Col<T> cg_solver_explicit(const arma::Mat<T>& X_nnz, const arma::Col<T>& c
 
 template <class T>
 T als_explicit(const dMappedCSC& Conf, arma::Mat<T>& X, arma::Mat<T>& Y,
-               const double lambda, const unsigned n_threads, const unsigned solver,
-               const unsigned cg_steps, const bool dynamic_lambda,
+               const double lambda, const int n_threads, const unsigned int solver,
+               const unsigned int cg_steps, const bool dynamic_lambda,
                const arma::Col<T>& cnt_X, const bool with_biases,
                const bool is_x_bias_last_row) {
   /* Note about biases:
@@ -63,7 +63,7 @@ T als_explicit(const dMappedCSC& Conf, arma::Mat<T>& X, arma::Mat<T>& Y,
       x_biases = X.row(0).t();
   }
 
-  T loss = 0;
+  double loss = 0;
   size_t nc = Conf.n_cols;
 #ifdef _OPENMP
 #pragma omp parallel for num_threads(n_threads) schedule(dynamic, GRAIN_SIZE) reduction(+:loss)

--- a/man/FTRL.Rd
+++ b/man/FTRL.Rd
@@ -16,8 +16,7 @@ y = sample(c(0, 1), 1000, TRUE)
 x = sample(c(-1, 1), 1000 * 100, TRUE)
 odd = seq(1, 99, 2)
 x[i \%in\% which(y == 1) & j \%in\% odd] = 1
-m = sparseMatrix(i = i, j = j, x = x, dims = c(1000, 1000), giveCsparse = FALSE)
-x = as(m, "RsparseMatrix")
+x = sparseMatrix(i = i, j = j, x = x, dims = c(1000, 1000), repr="R")
 
 ftrl = FTRL$new(learning_rate = 0.01, learning_rate_decay = 0.1,
 lambda = 10, l1_ratio = 1, dropout = 0)
@@ -26,7 +25,7 @@ ftrl$partial_fit(x, y)
 w = ftrl$coef()
 head(w)
 sum(w != 0)
-p = ftrl$predict(m)
+p = ftrl$predict(x)
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/man/MatrixFactorizationRecommender.Rd
+++ b/man/MatrixFactorizationRecommender.Rd
@@ -13,6 +13,9 @@ All matrix factorization recommenders inherit from this class
 \item{\code{components}}{item embeddings}
 
 \item{\code{global_bias}}{global mean (for centering values in explicit feedback)}
+
+\item{\code{global_bias_base}}{Pre-calculated `-(factors*global_bias)` (for centering values in
+implicit feedback when not using user/item biases)}
 }
 \if{html}{\out{</div>}}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -279,14 +279,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // c_nnls_double
-arma::Mat<double> c_nnls_double(const arma::mat& x, const arma::vec& y, uint max_iter, double rel_tol);
+arma::Mat<double> c_nnls_double(const arma::mat& x, const arma::vec& y, unsigned int max_iter, double rel_tol);
 RcppExport SEXP _rsparse_c_nnls_double(SEXP xSEXP, SEXP ySEXP, SEXP max_iterSEXP, SEXP rel_tolSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const arma::mat& >::type x(xSEXP);
     Rcpp::traits::input_parameter< const arma::vec& >::type y(ySEXP);
-    Rcpp::traits::input_parameter< uint >::type max_iter(max_iterSEXP);
+    Rcpp::traits::input_parameter< unsigned int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< double >::type rel_tol(rel_tolSEXP);
     rcpp_result_gen = Rcpp::wrap(c_nnls_double(x, y, max_iter, rel_tol));
     return rcpp_result_gen;
@@ -445,8 +445,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // als_implicit_double
-double als_implicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, const arma::mat& XtX, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, const bool with_biases, bool is_x_bias_last_row);
-RcppExport SEXP _rsparse_als_implicit_double(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP XtXSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP) {
+double als_implicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y, const arma::mat& XtX, double lambda, int n_threads, const unsigned int solver, const unsigned int cg_steps, const bool with_biases, const bool is_x_bias_last_row, const double global_bias, arma::vec& global_bias_base, const bool initialize_bias_base);
+RcppExport SEXP _rsparse_als_implicit_double(SEXP m_csc_rSEXP, SEXP XSEXP, SEXP YSEXP, SEXP XtXSEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP, SEXP global_biasSEXP, SEXP global_bias_baseSEXP, SEXP initialize_bias_baseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -455,18 +455,21 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< arma::mat& >::type Y(YSEXP);
     Rcpp::traits::input_parameter< const arma::mat& >::type XtX(XtXSEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
-    Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
-    Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
-    Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< int >::type n_threads(n_threadsSEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type solver(solverSEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type cg_steps(cg_stepsSEXP);
     Rcpp::traits::input_parameter< const bool >::type with_biases(with_biasesSEXP);
-    Rcpp::traits::input_parameter< bool >::type is_x_bias_last_row(is_x_bias_last_rowSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_implicit_double(m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row));
+    Rcpp::traits::input_parameter< const bool >::type is_x_bias_last_row(is_x_bias_last_rowSEXP);
+    Rcpp::traits::input_parameter< const double >::type global_bias(global_biasSEXP);
+    Rcpp::traits::input_parameter< arma::vec& >::type global_bias_base(global_bias_baseSEXP);
+    Rcpp::traits::input_parameter< const bool >::type initialize_bias_base(initialize_bias_baseSEXP);
+    rcpp_result_gen = Rcpp::wrap(als_implicit_double(m_csc_r, X, Y, XtX, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row, global_bias, global_bias_base, initialize_bias_base));
     return rcpp_result_gen;
 END_RCPP
 }
 // als_implicit_float
-double als_implicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& X_, Rcpp::S4& Y_, Rcpp::S4& XtX_, double lambda, unsigned n_threads, unsigned solver, unsigned cg_steps, const bool with_biases, bool is_x_bias_last_row);
-RcppExport SEXP _rsparse_als_implicit_float(SEXP m_csc_rSEXP, SEXP X_SEXP, SEXP Y_SEXP, SEXP XtX_SEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP) {
+double als_implicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& X_, Rcpp::S4& Y_, Rcpp::S4& XtX_, double lambda, int n_threads, const unsigned int solver, const unsigned int cg_steps, const bool with_biases, const bool is_x_bias_last_row, const double global_bias, Rcpp::S4& global_bias_base_, const bool initialize_bias_base);
+RcppExport SEXP _rsparse_als_implicit_float(SEXP m_csc_rSEXP, SEXP X_SEXP, SEXP Y_SEXP, SEXP XtX_SEXP, SEXP lambdaSEXP, SEXP n_threadsSEXP, SEXP solverSEXP, SEXP cg_stepsSEXP, SEXP with_biasesSEXP, SEXP is_x_bias_last_rowSEXP, SEXP global_biasSEXP, SEXP global_bias_base_SEXP, SEXP initialize_bias_baseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -475,18 +478,21 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::S4& >::type Y_(Y_SEXP);
     Rcpp::traits::input_parameter< Rcpp::S4& >::type XtX_(XtX_SEXP);
     Rcpp::traits::input_parameter< double >::type lambda(lambdaSEXP);
-    Rcpp::traits::input_parameter< unsigned >::type n_threads(n_threadsSEXP);
-    Rcpp::traits::input_parameter< unsigned >::type solver(solverSEXP);
-    Rcpp::traits::input_parameter< unsigned >::type cg_steps(cg_stepsSEXP);
+    Rcpp::traits::input_parameter< int >::type n_threads(n_threadsSEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type solver(solverSEXP);
+    Rcpp::traits::input_parameter< const unsigned int >::type cg_steps(cg_stepsSEXP);
     Rcpp::traits::input_parameter< const bool >::type with_biases(with_biasesSEXP);
-    Rcpp::traits::input_parameter< bool >::type is_x_bias_last_row(is_x_bias_last_rowSEXP);
-    rcpp_result_gen = Rcpp::wrap(als_implicit_float(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row));
+    Rcpp::traits::input_parameter< const bool >::type is_x_bias_last_row(is_x_bias_last_rowSEXP);
+    Rcpp::traits::input_parameter< const double >::type global_bias(global_biasSEXP);
+    Rcpp::traits::input_parameter< Rcpp::S4& >::type global_bias_base_(global_bias_base_SEXP);
+    Rcpp::traits::input_parameter< const bool >::type initialize_bias_base(initialize_bias_baseSEXP);
+    rcpp_result_gen = Rcpp::wrap(als_implicit_float(m_csc_r, X_, Y_, XtX_, lambda, n_threads, solver, cg_steps, with_biases, is_x_bias_last_row, global_bias, global_bias_base_, initialize_bias_base));
     return rcpp_result_gen;
 END_RCPP
 }
 // initialize_biases_double
-double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias);
-RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP) {
+double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias, bool is_explicit_feedback);
+RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP, SEXP is_explicit_feedbackSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -498,13 +504,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type dynamic_lambda(dynamic_lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
     Rcpp::traits::input_parameter< bool >::type calculate_global_bias(calculate_global_biasSEXP);
-    rcpp_result_gen = Rcpp::wrap(initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias));
+    Rcpp::traits::input_parameter< bool >::type is_explicit_feedback(is_explicit_feedbackSEXP);
+    rcpp_result_gen = Rcpp::wrap(initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback));
     return rcpp_result_gen;
 END_RCPP
 }
 // initialize_biases_float
-double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias);
-RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP) {
+double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias, bool is_explicit_feedback);
+RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP, SEXP is_explicit_feedbackSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -516,7 +523,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type dynamic_lambda(dynamic_lambdaSEXP);
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
     Rcpp::traits::input_parameter< bool >::type calculate_global_bias(calculate_global_biasSEXP);
-    rcpp_result_gen = Rcpp::wrap(initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias));
+    Rcpp::traits::input_parameter< bool >::type is_explicit_feedback(is_explicit_feedbackSEXP);
+    rcpp_result_gen = Rcpp::wrap(initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -551,10 +559,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_deep_copy", (DL_FUNC) &_rsparse_deep_copy, 1},
     {"_rsparse_als_explicit_double", (DL_FUNC) &_rsparse_als_explicit_double, 11},
     {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 11},
-    {"_rsparse_als_implicit_double", (DL_FUNC) &_rsparse_als_implicit_double, 10},
-    {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 10},
-    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 8},
-    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 8},
+    {"_rsparse_als_implicit_double", (DL_FUNC) &_rsparse_als_implicit_double, 13},
+    {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 13},
+    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 9},
+    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 9},
     {NULL, NULL, 0}
 };
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -491,8 +491,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // initialize_biases_double
-double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias, bool is_explicit_feedback);
-RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP, SEXP is_explicit_feedbackSEXP) {
+double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, arma::Col<double>& user_bias, arma::Col<double>& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias, bool is_explicit_feedback, const bool initialize_item_biases);
+RcppExport SEXP _rsparse_initialize_biases_double(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP, SEXP is_explicit_feedbackSEXP, SEXP initialize_item_biasesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -505,13 +505,14 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
     Rcpp::traits::input_parameter< bool >::type calculate_global_bias(calculate_global_biasSEXP);
     Rcpp::traits::input_parameter< bool >::type is_explicit_feedback(is_explicit_feedbackSEXP);
-    rcpp_result_gen = Rcpp::wrap(initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback));
+    Rcpp::traits::input_parameter< const bool >::type initialize_item_biases(initialize_item_biasesSEXP);
+    rcpp_result_gen = Rcpp::wrap(initialize_biases_double(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback, initialize_item_biases));
     return rcpp_result_gen;
 END_RCPP
 }
 // initialize_biases_float
-double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias, bool is_explicit_feedback);
-RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP, SEXP is_explicit_feedbackSEXP) {
+double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r, Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda, bool dynamic_lambda, bool non_negative, bool calculate_global_bias, bool is_explicit_feedback, const bool initialize_item_biases);
+RcppExport SEXP _rsparse_initialize_biases_float(SEXP m_csc_rSEXP, SEXP m_csr_rSEXP, SEXP user_biasSEXP, SEXP item_biasSEXP, SEXP lambdaSEXP, SEXP dynamic_lambdaSEXP, SEXP non_negativeSEXP, SEXP calculate_global_biasSEXP, SEXP is_explicit_feedbackSEXP, SEXP initialize_item_biasesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -524,7 +525,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type non_negative(non_negativeSEXP);
     Rcpp::traits::input_parameter< bool >::type calculate_global_bias(calculate_global_biasSEXP);
     Rcpp::traits::input_parameter< bool >::type is_explicit_feedback(is_explicit_feedbackSEXP);
-    rcpp_result_gen = Rcpp::wrap(initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback));
+    Rcpp::traits::input_parameter< const bool >::type initialize_item_biases(initialize_item_biasesSEXP);
+    rcpp_result_gen = Rcpp::wrap(initialize_biases_float(m_csc_r, m_csr_r, user_bias, item_bias, lambda, dynamic_lambda, non_negative, calculate_global_bias, is_explicit_feedback, initialize_item_biases));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -561,8 +563,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_rsparse_als_explicit_float", (DL_FUNC) &_rsparse_als_explicit_float, 11},
     {"_rsparse_als_implicit_double", (DL_FUNC) &_rsparse_als_implicit_double, 13},
     {"_rsparse_als_implicit_float", (DL_FUNC) &_rsparse_als_implicit_float, 13},
-    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 9},
-    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 9},
+    {"_rsparse_initialize_biases_double", (DL_FUNC) &_rsparse_initialize_biases_double, 10},
+    {"_rsparse_initialize_biases_float", (DL_FUNC) &_rsparse_initialize_biases_float, 10},
     {NULL, NULL, 0}
 };
 

--- a/src/rsparse.h
+++ b/src/rsparse.h
@@ -3,6 +3,8 @@
 #include "mapped_csr.hpp"
 
 #include <stdexcept>
+#include <limits>
+#include <cmath>
 
 #ifdef _OPENMP
 #include <omp.h>

--- a/src/wrmf_implicit.cpp
+++ b/src/wrmf_implicit.cpp
@@ -3,24 +3,29 @@
 
 // [[Rcpp::export]]
 double als_implicit_double(const Rcpp::S4& m_csc_r, arma::mat& X, arma::mat& Y,
-                           const arma::mat& XtX, double lambda, unsigned n_threads,
-                           unsigned solver, unsigned cg_steps, const bool with_biases,
-                           bool is_x_bias_last_row) {
+                           const arma::mat& XtX, double lambda, int n_threads,
+                           const unsigned int solver, const unsigned int cg_steps, const bool with_biases,
+                           const bool is_x_bias_last_row, const double global_bias,
+                           arma::vec& global_bias_base, const bool initialize_bias_base) {
   const dMappedCSC Conf = extract_mapped_csc(m_csc_r);
   return (double)als_implicit<double>(Conf, X, Y, XtX, lambda, n_threads, solver,
-                                      cg_steps, with_biases, is_x_bias_last_row);
+                                      cg_steps, with_biases, is_x_bias_last_row,
+                                      global_bias, global_bias_base, initialize_bias_base);
 }
 
 // [[Rcpp::export]]
 double als_implicit_float(const Rcpp::S4& m_csc_r, Rcpp::S4& X_, Rcpp::S4& Y_,
-                          Rcpp::S4& XtX_, double lambda, unsigned n_threads,
-                          unsigned solver, unsigned cg_steps, const bool with_biases,
-                          bool is_x_bias_last_row) {
+                          Rcpp::S4& XtX_, double lambda, int n_threads,
+                          const unsigned int solver, const unsigned int cg_steps, const bool with_biases,
+                          const bool is_x_bias_last_row, const double global_bias,
+                          Rcpp::S4& global_bias_base_, const bool initialize_bias_base) {
   const dMappedCSC Conf = extract_mapped_csc(m_csc_r);
   // get arma matrices which share memory with R "float" matrices
   arma::fmat X = extract_float_matrix(X_);
   arma::fmat Y = extract_float_matrix(Y_);
   arma::fmat XtX = extract_float_matrix(XtX_);
+  arma::fvec global_bias_base = extract_float_vector(global_bias_base_);
   return (double)als_implicit<float>(Conf, X, Y, XtX, lambda, n_threads, solver, cg_steps,
-                                     with_biases, is_x_bias_last_row);
+                                     with_biases, is_x_bias_last_row,
+                                     global_bias, global_bias_base, initialize_bias_base);
 }

--- a/src/wrmf_init.cpp
+++ b/src/wrmf_init.cpp
@@ -8,12 +8,13 @@ double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r
                                 arma::Col<double>& item_bias, double lambda,
                                 bool dynamic_lambda, bool non_negative,
                                 bool calculate_global_bias = false,
-                                bool is_explicit_feedback = false) {
+                                bool is_explicit_feedback = false,
+                                const bool initialize_item_biases = false) {
   dMappedCSC ConfCSC = extract_mapped_csc(m_csc_r);
   dMappedCSC ConfCSR = extract_mapped_csc(m_csr_r);
   return initialize_biases<double>(ConfCSC, ConfCSR, user_bias, item_bias, lambda,
                                    dynamic_lambda, non_negative, calculate_global_bias,
-                                   is_explicit_feedback);
+                                   is_explicit_feedback, initialize_item_biases);
 }
 
 // [[Rcpp::export]]
@@ -21,7 +22,8 @@ double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r,
                                Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda,
                                bool dynamic_lambda, bool non_negative,
                                bool calculate_global_bias = false,
-                               bool is_explicit_feedback = false) {
+                               bool is_explicit_feedback = false,
+                                const bool initialize_item_biases = false) {
   dMappedCSC ConfCSC = extract_mapped_csc(m_csc_r);
   dMappedCSC ConfCSR = extract_mapped_csc(m_csr_r);
 
@@ -30,5 +32,6 @@ double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r,
 
   return initialize_biases<float>(ConfCSC, ConfCSR, user_bias_arma, item_bias_arma,
                                   lambda, dynamic_lambda, non_negative,
-                                  calculate_global_bias, is_explicit_feedback);
+                                  calculate_global_bias, is_explicit_feedback,
+                                  initialize_item_biases);
 }

--- a/src/wrmf_init.cpp
+++ b/src/wrmf_init.cpp
@@ -7,18 +7,21 @@ double initialize_biases_double(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r
                                 arma::Col<double>& user_bias,
                                 arma::Col<double>& item_bias, double lambda,
                                 bool dynamic_lambda, bool non_negative,
-                                bool calculate_global_bias = false) {
+                                bool calculate_global_bias = false,
+                                bool is_explicit_feedback = false) {
   dMappedCSC ConfCSC = extract_mapped_csc(m_csc_r);
   dMappedCSC ConfCSR = extract_mapped_csc(m_csr_r);
   return initialize_biases<double>(ConfCSC, ConfCSR, user_bias, item_bias, lambda,
-                                   dynamic_lambda, non_negative, calculate_global_bias);
+                                   dynamic_lambda, non_negative, calculate_global_bias,
+                                   is_explicit_feedback);
 }
 
 // [[Rcpp::export]]
 double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r,
                                Rcpp::S4& user_bias, Rcpp::S4& item_bias, double lambda,
                                bool dynamic_lambda, bool non_negative,
-                               bool calculate_global_bias = false) {
+                               bool calculate_global_bias = false,
+                               bool is_explicit_feedback = false) {
   dMappedCSC ConfCSC = extract_mapped_csc(m_csc_r);
   dMappedCSC ConfCSR = extract_mapped_csc(m_csr_r);
 
@@ -27,5 +30,5 @@ double initialize_biases_float(const Rcpp::S4& m_csc_r, const Rcpp::S4& m_csr_r,
 
   return initialize_biases<float>(ConfCSC, ConfCSR, user_bias_arma, item_bias_arma,
                                   lambda, dynamic_lambda, non_negative,
-                                  calculate_global_bias);
+                                  calculate_global_bias, is_explicit_feedback);
 }


### PR DESCRIPTION
This PR fixes several issues with the user/item/global biases in `WRMF` with implicit feedback.

Some notes:
* There is something wrong with the loss (the one calculated for convergence by the solver) as it's higher for users than for items, even though both decrease after every iteration. I haven't yet figured out if it's because the loss is calculated incorrectly, or some off-by-one-error with the biases position, or some math error elsewhere. This is not caused by the additions here as it was already behaving like that before.
* The global biases have very poor numerical precision. Not sure how to fix that while still using armadillo. As it is right now, the loss will **increase** when using a global bias.
* This PR initializes the item factors to zero when using the Cholesky solver as the randomly-generated numbers there won't end up being used.
* The conjugate gradient solver will start diverging after some iterations if adding biases. I assume this is due to poor numerical precision.

Testing on the movielens100k, it looks like adding `with_user_item_bias=TRUE` with `with_global_bias=FALSE` leads to a decrease in the function that is to be minimized, but adding `with_global_bias=TRUE` makes the function higher (worse).